### PR TITLE
Add xtask pack/unpack commands for reliable grammar source transfer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,16 +28,14 @@ jobs:
       - name: Generate grammar sources
         run: arborium-xtask gen
 
-      - name: Create grammar sources tarball
-        run: |
-          find crates -type d -name 'src' -path '*/grammar/src' > grammar_dirs.txt
-          tar -cvf grammar-sources.tar -T grammar_dirs.txt
+      - name: Pack grammar sources
+        run: arborium-xtask pack create -o grammar-sources.tar.zst
 
       - name: Upload grammar sources
         uses: actions/upload-artifact@v4
         with:
           name: grammar-sources
-          path: grammar-sources.tar
+          path: grammar-sources.tar.zst
           retention-days: 1
 
   publish:
@@ -53,7 +51,7 @@ jobs:
           name: grammar-sources
 
       - name: Extract grammar sources
-        run: tar -xvf grammar-sources.tar
+        run: arborium-xtask pack extract -i grammar-sources.tar.zst
 
       - name: Publish to crates.io
         run: cargo publish --workspace

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3790,6 +3790,7 @@ dependencies = [
  "tiny_http",
  "toml",
  "ureq",
+ "walkdir",
  "wasm-opt",
  "which",
  "zopfli",

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -39,4 +39,5 @@ atomicwrites = "0.4"
 zstd = "0.13"
 wasm-opt = "0.116"
 zopfli = "0.8"
+walkdir = "2"
 # arborium = { path = "../crates/arborium", features = ["all-languages"] }  # TODO: re-enable for theme CSS generation and highlight linting

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -12,6 +12,7 @@ mod cache;
 mod ci;
 mod generate;
 mod lint_new;
+mod pack;
 mod plan;
 mod plugins;
 mod serve;
@@ -86,6 +87,12 @@ enum Command {
         #[facet(args::subcommand)]
         action: CiAction,
     },
+
+    /// Pack/unpack grammar sources for CI artifact transfer
+    Pack {
+        #[facet(args::subcommand)]
+        action: PackAction,
+    },
 }
 
 /// Plugin subcommands
@@ -152,6 +159,34 @@ enum CiAction {
         /// Check if files are up to date instead of generating
         #[facet(args::named, default)]
         check: bool,
+    },
+}
+
+/// Pack/unpack subcommands
+#[derive(Debug, Facet)]
+#[repr(u8)]
+#[allow(dead_code)]
+enum PackAction {
+    /// Pack grammar sources into a tar.zst archive
+    Create {
+        /// Output archive path (default: grammar-sources.tar.zst)
+        #[facet(args::named, args::short = 'o', default)]
+        output: Option<String>,
+
+        /// Repository root directory (default: auto-detect)
+        #[facet(args::named, default)]
+        repo: Option<String>,
+    },
+
+    /// Unpack grammar sources from a tar.zst archive
+    Extract {
+        /// Input archive path (default: grammar-sources.tar.zst)
+        #[facet(args::named, args::short = 'i', default)]
+        input: Option<String>,
+
+        /// Target directory to extract into (default: current directory)
+        #[facet(args::named, default)]
+        target: Option<String>,
     },
 }
 
@@ -318,6 +353,47 @@ fn main() {
             match action {
                 CiAction::Generate { check } => {
                     if let Err(e) = ci::generate(&repo_root, check) {
+                        eprintln!("{:?}", e);
+                        std::process::exit(1);
+                    }
+                }
+            }
+        }
+        Command::Pack { action } => {
+            match action {
+                PackAction::Create { output, repo } => {
+                    let repo_root = repo
+                        .map(camino::Utf8PathBuf::from)
+                        .or_else(|| {
+                            util::find_repo_root()
+                                .map(|p| camino::Utf8PathBuf::from_path_buf(p).expect("non-UTF8 path"))
+                        })
+                        .expect("Could not find repo root (use --repo to specify)");
+
+                    let output = output
+                        .map(camino::Utf8PathBuf::from)
+                        .unwrap_or_else(|| repo_root.join("grammar-sources.tar.zst"));
+
+                    if let Err(e) = pack::pack_grammar_sources(&repo_root, &output) {
+                        eprintln!("{:?}", e);
+                        std::process::exit(1);
+                    }
+                }
+                PackAction::Extract { input, target } => {
+                    let target_dir = target
+                        .map(camino::Utf8PathBuf::from)
+                        .unwrap_or_else(|| {
+                            camino::Utf8PathBuf::from_path_buf(
+                                std::env::current_dir().expect("Could not get current directory")
+                            )
+                            .expect("non-UTF8 path")
+                        });
+
+                    let input = input
+                        .map(camino::Utf8PathBuf::from)
+                        .unwrap_or_else(|| target_dir.join("grammar-sources.tar.zst"));
+
+                    if let Err(e) = pack::unpack_grammar_sources(&input, &target_dir) {
                         eprintln!("{:?}", e);
                         std::process::exit(1);
                     }

--- a/xtask/src/pack.rs
+++ b/xtask/src/pack.rs
@@ -1,0 +1,215 @@
+//! Pack and unpack grammar sources for CI artifact transfer
+//!
+//! This module provides reliable archive creation and extraction for grammar
+//! source files (parser.c, scanner.c, etc.) that are generated during the
+//! `gen` command and need to be transferred between CI jobs.
+
+use camino::{Utf8Path, Utf8PathBuf};
+use miette::{Context, IntoDiagnostic, Result};
+use owo_colors::OwoColorize;
+
+/// Pack grammar sources into a tar.zst archive
+pub fn pack_grammar_sources(repo_root: &Utf8Path, output: &Utf8Path) -> Result<()> {
+    let crates_dir = repo_root.join("crates");
+
+    println!(
+        "{} Packing grammar sources from {}",
+        "→".cyan(),
+        crates_dir
+    );
+
+    // Find all grammar/src directories
+    let mut grammar_dirs: Vec<Utf8PathBuf> = Vec::new();
+    for entry in fs_err::read_dir(&crates_dir)
+        .into_diagnostic()
+        .context("Failed to read crates directory")?
+    {
+        let entry = entry.into_diagnostic()?;
+        let path = Utf8PathBuf::from_path_buf(entry.path()).expect("non-UTF8 path");
+
+        if !path.is_dir() {
+            continue;
+        }
+
+        let grammar_src = path.join("grammar").join("src");
+        if grammar_src.is_dir() {
+            grammar_dirs.push(grammar_src);
+        }
+    }
+
+    if grammar_dirs.is_empty() {
+        miette::bail!("No grammar/src directories found in {}", crates_dir);
+    }
+
+    println!(
+        "  {} Found {} grammar directories",
+        "●".green(),
+        grammar_dirs.len()
+    );
+
+    // Create the tar archive
+    let output_file = fs_err::File::create(output)
+        .into_diagnostic()
+        .context(format!("Failed to create output file: {}", output))?;
+
+    // Wrap in zstd compression
+    let zstd_encoder = zstd::stream::Encoder::new(output_file, 3)
+        .into_diagnostic()
+        .context("Failed to create zstd encoder")?;
+
+    let mut tar_builder = tar::Builder::new(zstd_encoder);
+
+    let mut file_count = 0;
+    for grammar_src in &grammar_dirs {
+        // Add all files in this directory
+        for entry in walkdir::WalkDir::new(grammar_src)
+            .into_iter()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_type().is_file())
+        {
+            let file_path =
+                Utf8PathBuf::from_path_buf(entry.path().to_path_buf()).expect("non-UTF8 path");
+            let file_rel_path = file_path
+                .strip_prefix(repo_root)
+                .expect("file should be under repo_root");
+
+            let mut file = fs_err::File::open(&file_path)
+                .into_diagnostic()
+                .context(format!("Failed to open file: {}", file_path))?;
+
+            let metadata = file
+                .metadata()
+                .into_diagnostic()
+                .context(format!("Failed to read metadata: {}", file_path))?;
+
+            let mut header = tar::Header::new_gnu();
+            header.set_size(metadata.len());
+            header.set_mode(0o644);
+            header.set_mtime(0); // Reproducible builds
+            header.set_cksum();
+
+            tar_builder
+                .append_data(&mut header, file_rel_path, &mut file)
+                .into_diagnostic()
+                .context(format!("Failed to add file to archive: {}", file_rel_path))?;
+
+            file_count += 1;
+            println!("    {} {}", "+".green(), file_rel_path);
+        }
+    }
+
+    // Finish the tar archive and zstd compression
+    let zstd_encoder = tar_builder
+        .into_inner()
+        .into_diagnostic()
+        .context("Failed to finish tar archive")?;
+
+    zstd_encoder
+        .finish()
+        .into_diagnostic()
+        .context("Failed to finish zstd compression")?;
+
+    let output_size = fs_err::metadata(output)
+        .into_diagnostic()
+        .context("Failed to read output file size")?
+        .len();
+
+    println!(
+        "{} Packed {} files into {} ({:.2} KB)",
+        "✓".green().bold(),
+        file_count,
+        output,
+        output_size as f64 / 1024.0
+    );
+
+    Ok(())
+}
+
+/// Unpack grammar sources from a tar.zst archive
+pub fn unpack_grammar_sources(archive: &Utf8Path, repo_root: &Utf8Path) -> Result<()> {
+    println!(
+        "{} Unpacking grammar sources from {} to {}",
+        "→".cyan(),
+        archive,
+        repo_root
+    );
+
+    let archive_file = fs_err::File::open(archive)
+        .into_diagnostic()
+        .context(format!("Failed to open archive: {}", archive))?;
+
+    // Decompress zstd
+    let zstd_decoder = zstd::stream::Decoder::new(archive_file)
+        .into_diagnostic()
+        .context("Failed to create zstd decoder")?;
+
+    // Unpack tar
+    let mut tar_archive = tar::Archive::new(zstd_decoder);
+
+    let mut file_count = 0;
+    for entry in tar_archive
+        .entries()
+        .into_diagnostic()
+        .context("Failed to read tar entries")?
+    {
+        let mut entry = entry
+            .into_diagnostic()
+            .context("Failed to read tar entry")?;
+
+        let entry_path = entry
+            .path()
+            .into_diagnostic()
+            .context("Failed to get entry path")?;
+
+        let entry_path_str = entry_path.to_string_lossy();
+        let dest_path = repo_root.join(entry_path_str.as_ref());
+
+        // Create parent directories
+        if let Some(parent) = dest_path.parent() {
+            fs_err::create_dir_all(parent)
+                .into_diagnostic()
+                .context(format!("Failed to create directory: {}", parent))?;
+        }
+
+        // Extract file
+        let mut dest_file = fs_err::File::create(&dest_path)
+            .into_diagnostic()
+            .context(format!("Failed to create file: {}", dest_path))?;
+
+        std::io::copy(&mut entry, &mut dest_file)
+            .into_diagnostic()
+            .context(format!("Failed to write file: {}", dest_path))?;
+
+        file_count += 1;
+        println!("    {} {}", "→".green(), dest_path);
+    }
+
+    println!(
+        "{} Unpacked {} files",
+        "✓".green().bold(),
+        file_count
+    );
+
+    // Verify some key files exist
+    let crates_dir = repo_root.join("crates");
+    let mut verified = 0;
+    for entry in fs_err::read_dir(&crates_dir)
+        .into_diagnostic()
+        .context("Failed to read crates directory")?
+    {
+        let entry = entry.into_diagnostic()?;
+        let path = Utf8PathBuf::from_path_buf(entry.path()).expect("non-UTF8 path");
+        let parser_c = path.join("grammar").join("src").join("parser.c");
+        if parser_c.exists() {
+            verified += 1;
+        }
+    }
+
+    println!(
+        "  {} Verified {} crates have grammar/src/parser.c",
+        "●".green(),
+        verified
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- Adds `arborium-xtask pack create` and `arborium-xtask pack extract` commands
- Replaces flaky shell-based tar commands in release.yml with proper Rust implementation
- Uses tar+zstd for good compression (~30MB for all grammar sources)
- Reports exactly what files are compressed/extracted for easier debugging

## Test plan
- [x] Tested pack create locally - packs 589 files from 98 grammar directories
- [x] Tested pack extract locally - extracts and verifies all parser.c files exist
- [ ] CI should pass with the new workflow