### PR TITLE
Add HTML tag reference documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,92 @@ Enabling them may have implications for your project's licensing.
 | `lang-jinja2` | Jinja2 | GPL-3.0 | [tree-sitter-jinja2](https://github.com/dbt-labs/tree-sitter-jinja2) |
 | `lang-nginx` | nginx | GPL-3.0 | [tree-sitter-nginx](https://gitlab.com/joncoole/tree-sitter-nginx) |
 
+## HTML Tag Reference
+
+Arborium renders syntax highlighting using custom HTML elements. When highlighting code, it wraps spans of text with tags like `<a-k>`, `<a-f>`, etc. These tags are styled by the theme CSS you choose.
+
+### Tag Mappings
+
+Each tag corresponds to a semantic code element. Here's the complete reference:
+
+| Tag | Element Type | Description |
+|-----|--------------|-------------|
+| `<a-k>` | **Keyword** | Language keywords (if, else, while, class, fn, etc.) |
+| `<a-f>` | **Function** | Function names and method calls |
+| `<a-s>` | **String** | String literals and character literals |
+| `<a-c>` | **Comment** | Comments (line and block) |
+| `<a-t>` | **Type** | Type names and type annotations |
+| `<a-v>` | **Variable** | Variable names and identifiers |
+| `<a-co>` | **Constant** | Constants and boolean literals |
+| `<a-n>` | **Number** | Numeric literals (integers and floats) |
+| `<a-o>` | **Operator** | Operators (+, -, *, /, &&, etc.) |
+| `<a-p>` | **Punctuation** | Delimiters and punctuation (parentheses, brackets, commas) |
+| `<a-pr>` | **Property** | Object properties and struct fields |
+| `<a-at>` | **Attribute** | Attributes and annotations (@, #[derive], etc.) |
+| `<a-tg>` | **Tag** | HTML/XML tags |
+| `<a-m>` | **Macro** | Macro names and invocations |
+| `<a-l>` | **Label** | Labels and goto targets |
+| `<a-ns>` | **Namespace** | Namespaces and modules |
+| `<a-cr>` | **Constructor** | Constructor functions and type constructors |
+
+### Markup Tags (Markdown, etc.)
+
+| Tag | Element Type | Description |
+|-----|--------------|-------------|
+| `<a-tt>` | **Title** | Headings and titles |
+| `<a-st>` | **Strong** | Bold text |
+| `<a-em>` | **Emphasis** | Italic text |
+| `<a-tu>` | **Link** | URLs and hyperlinks |
+| `<a-tl>` | **Literal** | Code blocks and inline code |
+| `<a-tx>` | **Strikethrough** | Strikethrough text |
+
+### Diff Tags
+
+| Tag | Element Type | Description |
+|-----|--------------|-------------|
+| `<a-da>` | **Diff Add** | Added lines in diffs |
+| `<a-dd>` | **Diff Delete** | Deleted lines in diffs |
+
+### Special Tags
+
+| Tag | Element Type | Description |
+|-----|--------------|-------------|
+| `<a-eb>` | **Embedded** | Embedded language content |
+| `<a-er>` | **Error** | Syntax errors |
+
+### How It Works
+
+Arborium uses tree-sitter grammars to parse code and identify semantic elements. Multiple capture names from tree-sitter queries (like `@keyword.function`, `@keyword.import`, `@conditional`) all map to the same theme slot. For example:
+
+- `@keyword`, `@keyword.function`, `@include`, `@conditional` → all become `<a-k>` (keyword)
+- `@function`, `@function.builtin`, `@method` → all become `<a-f>` (function)
+- `@comment`, `@comment.documentation` → all become `<a-c>` (comment)
+
+Adjacent spans with the same tag are automatically merged into a single element for efficiency.
+
+### Styling Example
+
+To create a custom theme, target these elements in your CSS:
+
+```css
+/* Keywords in blue */
+a-k { color: #569cd6; }
+
+/* Functions in yellow */
+a-f { color: #dcdcaa; }
+
+/* Strings in green */
+a-s { color: #ce9178; }
+
+/* Comments in gray */
+a-c { color: #6a9955; font-style: italic; }
+
+/* Types in cyan */
+a-t { color: #4ec9b0; }
+```
+
+See the [included themes](https://github.com/bearcove/arborium/tree/main/packages/arborium/src/themes) for more examples.
+
 ## Sponsors
 
 Thanks to all individual sponsors:

--- a/demo/styles.css
+++ b/demo/styles.css
@@ -711,6 +711,29 @@ h1 {
     color: var(--fg);
 }
 
+/* Tag grid for HTML tag reference */
+.tag-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    gap: 0.5rem;
+    margin: 1rem 0;
+}
+
+.tag-item {
+    padding: 0.5rem;
+    background: var(--surface);
+    border-radius: 4px;
+    font-size: 0.85rem;
+    line-height: 1.4;
+}
+
+.tag-item code {
+    font-family: "Iosevka", "SF Mono", "Fira Code", "Consolas", monospace;
+    font-size: 0.85rem;
+    color: var(--accent);
+    font-weight: 600;
+}
+
 .cards-container code {
     font-family: "Iosevka", "SF Mono", "Fira Code", "Consolas", monospace;
     font-size: 0.85em;

--- a/xtask/templates/index.stpl.html
+++ b/xtask/templates/index.stpl.html
@@ -170,6 +170,7 @@
                 <a href="#integrations" class="nav-link">Integrations</a>
                 <a href="#languages" class="nav-link">Languages</a>
                 <a href="#themes" class="nav-link">Themes</a>
+                <a href="#html-tags" class="nav-link">HTML Tags</a>
                 <a href="#faq" class="nav-link">FAQ</a>
             </nav>
 
@@ -367,6 +368,58 @@
                     <p>
                         Custom themes can be defined programmatically using RGB colors and style
                         attributes (bold, italic, underline, strikethrough).
+                    </p>
+                </div>
+
+                <div class="about-card" id="html-tags">
+                    <h3>HTML Tag Reference</h3>
+                    <p>
+                        Arborium uses custom HTML elements to mark up syntax. Each tag corresponds to a semantic code element.
+                        To create custom themes, target these elements in your CSS.
+                    </p>
+
+                    <h4>Core Tags</h4>
+                    <div class="tag-grid">
+                        <div class="tag-item"><code>&lt;a-k&gt;</code> — Keyword</div>
+                        <div class="tag-item"><code>&lt;a-f&gt;</code> — Function</div>
+                        <div class="tag-item"><code>&lt;a-s&gt;</code> — String</div>
+                        <div class="tag-item"><code>&lt;a-c&gt;</code> — Comment</div>
+                        <div class="tag-item"><code>&lt;a-t&gt;</code> — Type</div>
+                        <div class="tag-item"><code>&lt;a-v&gt;</code> — Variable</div>
+                        <div class="tag-item"><code>&lt;a-co&gt;</code> — Constant</div>
+                        <div class="tag-item"><code>&lt;a-n&gt;</code> — Number</div>
+                        <div class="tag-item"><code>&lt;a-o&gt;</code> — Operator</div>
+                        <div class="tag-item"><code>&lt;a-p&gt;</code> — Punctuation</div>
+                        <div class="tag-item"><code>&lt;a-pr&gt;</code> — Property</div>
+                        <div class="tag-item"><code>&lt;a-at&gt;</code> — Attribute</div>
+                        <div class="tag-item"><code>&lt;a-tg&gt;</code> — Tag (HTML/XML)</div>
+                        <div class="tag-item"><code>&lt;a-m&gt;</code> — Macro</div>
+                        <div class="tag-item"><code>&lt;a-l&gt;</code> — Label</div>
+                        <div class="tag-item"><code>&lt;a-ns&gt;</code> — Namespace</div>
+                        <div class="tag-item"><code>&lt;a-cr&gt;</code> — Constructor</div>
+                    </div>
+
+                    <h4>Markup Tags</h4>
+                    <div class="tag-grid">
+                        <div class="tag-item"><code>&lt;a-tt&gt;</code> — Title/Heading</div>
+                        <div class="tag-item"><code>&lt;a-st&gt;</code> — Strong/Bold</div>
+                        <div class="tag-item"><code>&lt;a-em&gt;</code> — Emphasis/Italic</div>
+                        <div class="tag-item"><code>&lt;a-tu&gt;</code> — Link/URL</div>
+                        <div class="tag-item"><code>&lt;a-tl&gt;</code> — Literal/Code</div>
+                        <div class="tag-item"><code>&lt;a-tx&gt;</code> — Strikethrough</div>
+                    </div>
+
+                    <h4>Diff & Special</h4>
+                    <div class="tag-grid">
+                        <div class="tag-item"><code>&lt;a-da&gt;</code> — Diff Addition</div>
+                        <div class="tag-item"><code>&lt;a-dd&gt;</code> — Diff Deletion</div>
+                        <div class="tag-item"><code>&lt;a-eb&gt;</code> — Embedded</div>
+                        <div class="tag-item"><code>&lt;a-er&gt;</code> — Error</div>
+                    </div>
+
+                    <p>
+                        For the complete reference with examples and CSS styling tips, see the
+                        <a href="https://github.com/bearcove/arborium#html-tag-reference">HTML Tag Reference in the README</a>.
                     </p>
                 </div>
 


### PR DESCRIPTION
Fixes #37

This PR adds comprehensive documentation for all HTML custom elements that arborium generates during syntax highlighting.

## Changes

### README.md
- Added complete HTML Tag Reference section
- Documented all 28+ tags organized by category:
  - Core tags (17): `<a-k>`, `<a-f>`, `<a-s>`, `<a-c>`, `<a-t>`, etc.
  - Markup tags (6): `<a-tt>`, `<a-st>`, `<a-em>`, `<a-tu>`, `<a-tl>`, `<a-tx>`
  - Diff tags (2): `<a-da>`, `<a-dd>`
  - Special tags (2): `<a-eb>`, `<a-er>`
- Explained the capture-to-slot mapping system
- Provided CSS styling examples for creating custom themes

### Demo Website (xtask/templates/index.stpl.html)
- Added new "HTML Tags" navigation item
- Created dedicated section showing all tags organized by category
- Links to README for complete reference

### CSS Styling (demo/styles.css)
- Added `.tag-grid` responsive grid layout
- Styled `.tag-item` cards to match site design

## Why This Matters

Users integrating arborium (like the rustdoc integration mentioned in #37) need to know which HTML tags are emitted so they can create custom CSS themes to style the highlighted code. This documentation provides:

1. Complete list of all tags and their semantic meanings
2. Understanding of how tree-sitter captures map to HTML tags
3. Examples showing how to style the output with CSS

The mapping is transparent and well-documented, enabling users to create themes that target specific semantic elements.