### PR TITLE
Fix Jinja2 grammar license: GPL-3.0 → Apache-2.0

### DIFF
--- a/LICENSES.md
+++ b/LICENSES.md
@@ -27,14 +27,15 @@ You may choose either license at your option.
 | tree-sitter-scss | MIT | Copyright (c) 2024 Amaan Qureshi |
 | tree-sitter-toml | MIT | Copyright (c) Ika |
 | tree-sitter-zig | MIT | Copyright (c) 2022 maxxnino |
+| tree-sitter-jinja2 | Apache-2.0 | Copyright dbt Labs |
 
 ### GPL Licensed (opt-in only)
 
 | Grammar | License | Copyright |
 |---------|---------|-----------|
-| tree-sitter-jinja2 | GPL-3.0 | Copyright dbt Labs |
+| tree-sitter-nginx | GPL-3.0 | Copyright Jon Coole |
 
-**Warning**: Enabling `gpl-grammars` or `lang-jinja2` features will include GPL-3.0 licensed code, which may have implications for your project's licensing.
+**Warning**: Enabling `gpl-grammars` features will include GPL-3.0 licensed code, which may have implications for your project's licensing.
 
 ---
 
@@ -362,8 +363,8 @@ Affirmer's express Statement of Purpose.
   CC0 or use of the Work.
 ```
 
-### GPL-3.0 (applies only to tree-sitter-jinja2)
+### GPL-3.0 (applies only to tree-sitter-nginx)
 
 The full GPL-3.0 license text can be found at: https://www.gnu.org/licenses/gpl-3.0.txt
 
-This license only applies when the `gpl-grammars` or `lang-jinja2` feature is enabled.
+This license only applies when the `gpl-grammars` or `lang-nginx` feature is enabled.

--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ These grammars use permissive licenses (MIT, Apache-2.0, CC0, Unlicense) and are
 | `lang-ini` | INI | Apache-2.0 | [tree-sitter-ini](https://github.com/justinmk/tree-sitter-ini) |
 | `lang-java` | Java | MIT | [tree-sitter-java](https://github.com/tree-sitter/tree-sitter-java) |
 | `lang-javascript` | JavaScript | MIT | [tree-sitter-javascript](https://github.com/tree-sitter/tree-sitter-javascript) |
+| `lang-jinja2` | Jinja2 | Apache-2.0 | [tree-sitter-jinja2](https://github.com/dbt-labs/tree-sitter-jinja2) |
 | `lang-jq` | jq | MIT | [tree-sitter-jq](https://github.com/flurie/tree-sitter-jq) |
 | `lang-json` | JSON | MIT | [tree-sitter-json](https://github.com/tree-sitter/tree-sitter-json) |
 | `lang-lean` | Lean | MIT | [tree-sitter-lean](https://github.com/Julian/tree-sitter-lean) |
@@ -220,14 +221,13 @@ These grammars use permissive licenses (MIT, Apache-2.0, CC0, Unlicense) and are
 | `lang-zig` | Zig | MIT | [tree-sitter-zig](https://github.com/tree-sitter-grammars/tree-sitter-zig) |
 | `lang-zsh` | Zsh | MIT | [tree-sitter-zsh](https://github.com/georgeharker/tree-sitter-zsh) |
 
-### GPL-Licensed Grammars (2)
+### GPL-Licensed Grammars (1)
 
 These grammars are **not included by default** due to their copyleft license.
 Enabling them may have implications for your project's licensing.
 
 | Feature | Language | License | Source |
 |---------|----------|---------|--------|
-| `lang-jinja2` | Jinja2 | GPL-3.0 | [tree-sitter-jinja2](https://github.com/dbt-labs/tree-sitter-jinja2) |
 | `lang-nginx` | nginx | GPL-3.0 | [tree-sitter-nginx](https://gitlab.com/joncoole/tree-sitter-nginx) |
 
 ## HTML Tag Reference

--- a/langs/group-willow/jinja2/def/arborium.kdl
+++ b/langs/group-willow/jinja2/def/arborium.kdl
@@ -1,6 +1,6 @@
 repo "https://github.com/dbt-labs/tree-sitter-jinja2"
 commit "922b28e1352c4966418b2e7e3772e0583d4532a2"
-license "GPL-3.0"
+license "Apache-2.0"
 
 grammar {
     id "jinja2"


### PR DESCRIPTION
Corrects the license documentation for the tree-sitter-jinja2 grammar, which is actually licensed under Apache 2.0 rather than GPL-3.0. This resolves the discrepancy reported in #73.

The Jinja2 grammar is now listed as a permissively licensed grammar instead of a copyleft grammar, allowing it to be included by default.