### PR TITLE
Fix #78: Use arborium's native span API instead of HTML parsing

### DIFF
--- a/crates/arborium-highlight/src/lib.rs
+++ b/crates/arborium-highlight/src/lib.rs
@@ -106,8 +106,8 @@ mod types;
 pub mod tree_sitter;
 
 pub use render::{
-    AnsiOptions, html_escape, spans_to_ansi, spans_to_ansi_with_options, spans_to_html,
-    write_spans_as_ansi, write_spans_as_html,
+    AnsiOptions, ThemedSpan, html_escape, spans_to_ansi, spans_to_ansi_with_options, spans_to_html,
+    spans_to_themed, write_spans_as_ansi, write_spans_as_html,
 };
 pub use types::{HighlightError, Injection, ParseResult, Span};
 

--- a/crates/arborium/src/highlighter.rs
+++ b/crates/arborium/src/highlighter.rs
@@ -169,7 +169,7 @@ impl Highlighter {
     }
 
     /// Highlight and return raw spans (for custom rendering).
-    fn highlight_spans(&mut self, language: &str, source: &str) -> Result<Vec<Span>, Error> {
+    pub fn highlight_spans(&mut self, language: &str, source: &str) -> Result<Vec<Span>, Error> {
         // Get the primary grammar
         let grammar = self
             .store


### PR DESCRIPTION
## Summary

Fixes #78 by eliminating the fragile HTML parsing in miette-arborium and using arborium's proper span API instead.

## Changes

### arborium/arborium-highlight
- Added `ThemedSpan` type representing a span with a resolved theme index
- Added `spans_to_themed()` function that handles deduplication and theme mapping
- Made this logic reusable instead of being buried in ANSI rendering

### arborium
- Made `Highlighter::highlight_spans()` public to expose raw syntax spans
- Exported `ThemedSpan` and `spans_to_themed` from the umbrella crate

### miette-arborium
- **Removed all HTML parsing code** (parse_html_to_spans, decode_html_entities, tag_to_capture, style_for_tag)
- Now uses `highlight_spans() → spans_to_themed() → owo_colors` directly
- Highlights entire source once upfront, then slices themed spans per line
- Added `showcase` feature bundle for the example

## Benefits

✅ No more fragile HTML parsing that broke on nested tags
✅ Proper handling of TOML and other complex syntax
✅ Simpler, more maintainable code
✅ Reuses battle-tested logic from arborium-highlight
✅ All tests pass

## Testing

The `miette_showcase` example now works correctly with proper syntax highlighting:

```bash
cargo run --example miette_showcase
```