### PR TITLE
Print errors properly on CLI args parse failure

### DIFF
--- a/crates/arborium-cli/src/main.rs
+++ b/crates/arborium-cli/src/main.rs
@@ -33,7 +33,11 @@ struct Args {
 
 fn main() {
     let args: Args = facet_args::from_std_args().unwrap_or_else(|e| {
-        eprintln!("Error: {:?}", e);
+        if let Some(text) = e.help_text() {
+            eprintln!("{text}");
+        } else {
+            eprintln!("{:?}", miette::Report::new(e));
+        }
         std::process::exit(1);
     });
 

--- a/xtask/src/generate.rs
+++ b/xtask/src/generate.rs
@@ -2666,6 +2666,7 @@ all-languages = [
 arborium = {{ version = "{version}", path = "../arborium" }}
 facet = "0.33.0"
 facet-args = "0.33.0"
+miette = {{ version = "7.6.0", features = ["fancy-no-backtrace"] }}
 "#
     ));
 


### PR DESCRIPTION
arborium-cli used to print just the debug representation of the error, which is rather unwieldy

```
Error: ArgsErrorWithInput { inner: ArgsError { span: Span { start: 0, len: 9 }, kind: UnknownLongFlag { flag: "version", fields: [Field { name: "lang", shape: Shape { type_identifier: "Option", type_params: «(T: String)», inner: Shape { type_identifier: "String", ty: User(Opaque), layout: Sized(«24 align 8»), def: Scalar, .. }, ty: User(Opaque), layout: Sized(«24 align 8»), def: Option<String>, .. }, offset: 0, flags: (empty), rename: None, alias: None, attributes: [args::named(()), args::short(<Attr @ 0x55db987d98dc>)], doc: [], default: Some(FromTrait), skip_serializing_if: None, invariants: None, proxy: None, metadata: None }, Field { name: "html", shape: Shape { type_identifier: "bool", ty: Primitive(Boolean), layout: Sized(«1 align 1»), def: Scalar, .. }, offset: 72, flags: (empty), rename: None, alias: None, attributes: [args::named(())], doc: [], default: Some(FromTrait), skip_serializing_if: None, invariants: None, proxy: None, metadata: None }, Field { name: "input", shape: Shape { type_identifier: "Option", type_params: «(T: String)», inner: Shape { type_identifier: "String", ty: User(Opaque), layout: Sized(«24 align 8»), def: Scalar, .. }, ty: User(Opaque), layout: Sized(«24 align 8»), def: Option<String>, .. }, offset: 24, flags: (empty), rename: None, alias: None, attributes: [args::positional(())], doc: [], default: Some(FromTrait), skip_serializing_if: None, invariants: None, proxy: None, metadata: None }, Field { name: "theme", shape: Shape { type_identifier: "Option", type_params: «(T: String)», inner: Shape { type_identifier: "String", ty: User(Opaque), layout: Sized(«24 align 8»), def: Scalar, .. }, ty: User(Opaque), layout: Sized(«24 align 8»), def: Option<String>, .. }, offset: 48, flags: (empty), rename: None, alias: None, attributes: [args::named(())], doc: [], default: Some(FromTrait), skip_serializing_if: None, invariants: None, proxy: None, metadata: None }] } }, flattened_args: "--version " }
```

This imports miette to use its error reporting facilities with produces much better

<img width="768" height="552" alt="image" src="https://github.com/user-attachments/assets/9172a6ec-11d6-4bc9-ae5c-13656ce6f06c" />

(It probably would be polite to actually respond to `--version`, but maybe this should be done in facet_args?)

This also fixes `--help`, which used to print

```
Error: ArgsErrorWithInput { inner: ArgsError { span: Span { start: 0, len: 6 }, kind: HelpRequested { help_text: "./result/bin/arborium\n\n\u{1b}[1m\u{1b}[33mUSAGE\u{1b}[39m\u{1b}[0m:\n    ./result/bin/arborium [OPTIONS] [INPUT]\n\n\u{1b}[1m\u{1b}[33mARGUMENTS\u{1b}[39m\u{1b}[0m:\n        \u{1b}[32m<INPUT>\u{1b}[39m\n\n\u{1b}[1m\u{1b}[33mOPTIONS\u{1b}[39m\u{1b}[0m:\n    \u{1b}[32m-l\u{1b}[39m, \u{1b}[32m--lang\u{1b}[39m <OPTION>\n        \u{1b}[32m--html\u{1b}[39m\n        \u{1b}[32m--theme\u{1b}[39m <OPTION>\n\n" } }, flattened_args: "--help" }
```