### PR TITLE
Unify CI and grammar cache keys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,17 +40,29 @@ jobs:
         shell: bash
         id: version
       - 
-        name: Restore grammar generation cache
+        name: Restore xtask cache
         uses: actions/cache@v4
         with: 
-          path: .cache/arborium
-          key: "grammar-cache-v1000-${{ hashFiles('langs/group-*/*/def/grammar/grammar.js', 'langs/group-*/*/def/grammar/package.json') }}"
-          restore-keys: grammar-cache-v1000-
+          path: xtask/target
+          key: "xtask-${{ hashFiles('xtask/Cargo.lock', 'xtask/src/**/*.rs') }}"
 
       - 
         name: Build xtask
         run: "set -e\ncargo build --release --manifest-path xtask/Cargo.toml"
         shell: bash
+      - 
+        name: Compute grammar cache key
+        run: "set -e\necho \"key=$(./xtask/target/release/xtask cache-key)\" >> $GITHUB_OUTPUT"
+        shell: bash
+        id: grammar-cache-key
+      - 
+        name: Restore grammar generation cache
+        uses: actions/cache@v4
+        with: 
+          path: .cache/arborium
+          key: "grammar-v1-${{ hashFiles('xtask/Cargo.lock', 'xtask/src/**/*.rs') }}-${{ steps.grammar-cache-key.outputs.key }}"
+          restore-keys: "grammar-v1-${{ hashFiles('xtask/Cargo.lock', 'xtask/src/**/*.rs') }}-"
+
       - 
         name: Generate grammar sources
         run: "set -e\n./xtask/target/release/xtask gen --version ${{ steps.version.outputs.version }} --quiet"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -43,6 +43,9 @@ enum Command {
     /// Print version information
     Version,
 
+    /// Print global cache key for CI (combines all grammar cache keys)
+    CacheKey,
+
     /// Generate plugins-manifest.ts for the npm package (used by prepublishOnly)
     GenManifest,
 
@@ -263,6 +266,15 @@ fn main() {
 
     match args.command {
         Command::Version => unreachable!(),
+        Command::CacheKey => {
+            match cache::compute_global_cache_key(&repo_root) {
+                Ok(key) => println!("{}", key),
+                Err(e) => {
+                    eprintln!("Error computing cache key: {}", e);
+                    std::process::exit(1);
+                }
+            }
+        }
         Command::GenManifest => {
             let repo_root = util::find_repo_root().expect("Could not find repo root");
             let repo_root = camino::Utf8PathBuf::from_path_buf(repo_root).expect("non-UTF8 path");


### PR DESCRIPTION
## Summary
CI grammar cache didn't invalidate when generator code changed, causing stale parsers to be published (e.g., PR #77's ABI 15 fix didn't take effect).

## Solution
Two-layer caching:
1. **xtask cache**: keyed on `xtask/Cargo.lock` + `xtask/src/**/*.rs`
2. **grammar cache**: keyed on xtask hash + `xtask cache-key` output, with `restore-keys` for incremental rebuilds

The `xtask cache-key` command reuses existing `compute_cache_key()` logic (tree-sitter version, grammar files, dependencies).