### PR TITLE
docs: add supported languages list to lib.rs documentation

### DIFF
--- a/xtask/templates/umbrella_lib.stpl.rs
+++ b/xtask/templates/umbrella_lib.stpl.rs
@@ -59,6 +59,26 @@
 //! arborium = { version = "0.1", features = ["all-languages"] }
 //! ```
 //!
+//! ## Supported Languages
+//!
+//! ### Permissively Licensed (<%= permissive_grammars.len() %> languages, included by default)
+//!
+//! | Language | Feature Flag | License |
+//! |----------|--------------|---------|
+<% for grammar in permissive_grammars { %>
+//! | <%= grammar.name %> | `<%= grammar.feature %>` | <%= grammar.license %> |
+<% } %>
+//!
+//! ### GPL Licensed (<%= gpl_grammars.len() %> languages, opt-in)
+//!
+//! These require explicit opt-in via feature flags due to their copyleft license.
+//!
+//! | Language | Feature Flag | License |
+//! |----------|--------------|---------|
+<% for grammar in gpl_grammars { %>
+//! | <%= grammar.name %> | `<%= grammar.feature %>` | <%= grammar.license %> |
+<% } %>
+//!
 //! # Advanced Usage
 //!
 //! For building custom grammar providers or working with raw spans, see the


### PR DESCRIPTION
## Summary

Adds a complete table of supported languages to the crate-level documentation, making it visible on docs.rs. Users can now easily find the full list of available languages with their feature flags and licenses without having to dig through crates.io or the README.

## Changes

- Updated `umbrella_lib.stpl.rs` template to include a "Supported Languages" section in the doc comments
- Added `permissive_grammars` and `gpl_grammars` fields to `UmbrellaLibRsTemplate` struct  
- Moved grammar collection logic earlier in the generation process so it's available for both lib.rs and README generation

## Test plan

- [x] `cargo xtask gen` regenerates files successfully
- [x] `cargo check --lib --all-features` passes
- [x] Generated lib.rs includes the language tables (76 permissive + 1 GPL)

Fixes #98