### PR TITLE
Switch from facet-dev to bearcove/captain for git hooks

### DIFF
--- a/.cargo-husky/hooks/pre-commit
+++ b/.cargo-husky/hooks/pre-commit
@@ -1,5 +1,0 @@
-cargo install --git https://github.com/facet-rs/facet-dev
-facet-dev generate
-
-cargo xtask ci generate
-git add .github/workflows/ci.yml

--- a/.cargo-husky/hooks/pre-push
+++ b/.cargo-husky/hooks/pre-push
@@ -1,3 +1,0 @@
-cargo install --git https://github.com/facet-rs/facet-dev
-facet-dev pre-push
-

--- a/.config/captain/config.kdl
+++ b/.config/captain/config.kdl
@@ -1,0 +1,25 @@
+// Captain configuration
+// All options default to #true. Use #false to disable.
+// See: https://kdl.dev for KDL syntax
+
+pre-commit {
+    generate-readmes #false
+    // rustfmt #false
+    // cargo-lock #false
+    // arborium #false
+    // rust-version #false
+    // edition-2024 #false
+}
+
+pre-push {
+    clippy #false
+    nextest #false
+    doc-tests #false
+    docs #false
+    cargo-shear #false
+
+    // Feature configuration (uncomment and customize as needed)
+    // clippy-features "feature1" "feature2"
+    // doc-test-features "feature1"
+    // docs-features "feature1"
+}

--- a/hooks/install.sh
+++ b/hooks/install.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HOOK_SOURCE_DIR="$(git rev-parse --show-toplevel)/hooks"
+GIT_DIR="$(git rev-parse --git-dir)"
+
+copy_hook() {
+  local src="$1"
+  local dst="$2"
+
+  mkdir -p "$(dirname "$dst")"
+  cp "$src" "$dst"
+  chmod +x "$dst"
+
+  echo "✔ installed $(basename "$src") → $dst"
+}
+
+install_for_dir() {
+  local hook_dir="$1"
+
+  for hook in "$HOOK_SOURCE_DIR"/*; do
+    local name
+    name="$(basename "$hook")"
+    # Skip install.sh itself
+    if [ "$name" = "install.sh" ]; then
+      continue
+    fi
+    local target="$hook_dir/$name"
+
+    copy_hook "$hook" "$target"
+  done
+}
+
+echo "Installing hooks from $HOOK_SOURCE_DIR …"
+
+# main repo
+install_for_dir "$GIT_DIR/hooks"
+
+# worktrees
+for wt in "$GIT_DIR"/worktrees/*; do
+  if [ -d "$wt" ]; then
+    install_for_dir "$wt/hooks"
+  fi
+done
+
+echo "All hooks installed successfully."

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,2 @@
+#!/bin/bash
+captain

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,0 +1,2 @@
+#!/bin/bash
+captain pre-push

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -49,6 +49,3 @@ serde_json = "1.0.145"
 walrus = "0.20"
 petgraph = "0.7"
 
-[package.metadata.facet-dev]
-generate-readmes = false
-


### PR DESCRIPTION
facet-dev is deprecated, captain is where it's at. We only want the nice precommit hooks.
