### PR TITLE
fix: use and override config correctly

### DIFF
--- a/packages/arborium/src/index.ts
+++ b/packages/arborium/src/index.ts
@@ -4,7 +4,7 @@
  * ESM entry point for programmatic usage.
  */
 
-export { loadGrammar, highlight, spansToHtml, getConfig } from './loader.js';
+export { loadGrammar, highlight, spansToHtml, getConfig, setConfig } from './loader.js';
 export { detectLanguage, extractLanguageFromClass, normalizeLanguage } from './detect.js';
 export { pluginVersion, availableLanguages, highlights } from './plugins-manifest.js';
 export type {


### PR DESCRIPTION
Since `setConfig` isn’t exported in the NPM packages, and the `_config` parameters are never used, there is no way to actually configure arborium in the NPM version.

I changed it so
- all public functions optionally take config overrides
- all private functions take the full config
- `setConfig` is exported
- internally renamed `config` to `globalConfig` so it’s clear when it’s used.

This way, people should be able to both permanently change the global config and temporarily override the config when calling other APIs (like `loadGrammar`).

Possible variants:
- don’t export the global config at all in the NPM package, only IIFE (remove `getConfig` and don’t add the `setConfig` export in `index.ts`)
- also export the default config so people can reset the global config via `setConfig(defaultConfig)`

> [!WARNING]
> I didn’t actually test this yet!