### PR TITLE
feat: add `get_language` function to retrieve `Language` by name

### DIFF
--- a/crates/arborium/tests/language.rs
+++ b/crates/arborium/tests/language.rs
@@ -1,0 +1,18 @@
+//! Tree Sitter Language construction tests.
+//!
+//! Tests that verify grammar construction works as expected.
+
+#![cfg(feature = "lang-rust")]
+
+use arborium;
+
+#[test]
+fn get_rust() {
+    assert!(arborium::get_language("rust").is_some());
+}
+
+#[test]
+fn get_unsupported() {
+    // a fictional (and therefore unsupported) language named "bartholomew"
+    assert!(arborium::get_language("bartholomew").is_none());
+}

--- a/xtask/templates/umbrella_lib.stpl.rs
+++ b/xtask/templates/umbrella_lib.stpl.rs
@@ -191,6 +191,35 @@ pub fn detect_language(path: &str) -> Option<&'static str> {
     })
 }
 
+/// Get the tree-sitter [`Language`] for a given language name.
+///
+/// Returns the `Language` struct instance if the language is enabled via feature flags,
+/// or `None` if the language is not recognized or not enabled.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use arborium::get_language;
+///
+/// if let Some(lang) = get_language("rust") {
+///     // Use the Language instance...
+/// }
+/// ```
+///
+/// # Note
+///
+/// This function only returns languages that are enabled via feature flags.
+/// Use [`detect_language`] to map file paths to language names first.
+pub fn get_language(name: &str) -> Option<tree_sitter::Language> {
+    match name {
+<% for (_, grammar_id) in grammars { %>
+        #[cfg(feature = "lang-<%= grammar_id %>")]
+        "<%= grammar_id %>" => Some(lang_<%= grammar_id.replace('-', "_") %>::language().into()),
+<% } %>
+        _ => None,
+    }
+}
+
 // =============================================================================
 // Language grammar re-exports based on enabled features.
 // Each module provides:


### PR DESCRIPTION
The new `get_language` function takes a language name (as a string slice) and returns an `Option<Language>`. If no grammar for the provided language name is found, the function returns `None`. This commit closes #105.

> [!NOTE]
> The `get_language` template function and associated documentation was initially generated with *Claude Opus 4.5 Thinking*.

---

test: add `language.rs` integration test file with simple `get_language` tests
