### PR TITLE
feat(solidity): add config, grammar and queries

### DIFF
--- a/demo/samples/groovy.groovy
+++ b/demo/samples/groovy.groovy
@@ -1,0 +1,138 @@
+// Apache Groovy Example - Basic Syntax Features
+// Demonstrates classes, properties, methods, closures, and operators
+
+package com.example
+
+import java.util.concurrent.TimeUnit
+
+/**
+ * A Person class demonstrating Groovy's concise syntax
+ */
+class Person {
+    String firstName
+    String lastName
+    int age
+
+    // Constructor with named parameters
+    Person(Map params) {
+        this.firstName = params.firstName
+        this.lastName = params.lastName
+        this.age = params.age ?: 0
+    }
+
+    // Method with string interpolation
+    String greet() {
+        return "Hello, I'm ${firstName} ${lastName} and I'm ${age} years old"
+    }
+
+    // Operator overloading
+    Person plus(int years) {
+        return new Person(
+            firstName: this.firstName,
+            lastName: this.lastName,
+            age: this.age + years
+        )
+    }
+}
+
+// Closures and higher-order functions
+def numbers = [1, 2, 3, 4, 5]
+def doubled = numbers.collect { it * 2 }
+def evens = numbers.findAll { it % 2 == 0 }
+
+println "Original: ${numbers}"
+println "Doubled: ${doubled}"
+println "Even numbers: ${evens}"
+
+// Safe navigation operator
+def person = new Person(firstName: 'Alice', lastName: 'Smith', age: 30)
+println person?.greet()
+
+// Elvis operator for null-safety
+def name = null
+def displayName = name ?: 'Anonymous'
+println "Display name: ${displayName}"
+
+// Ranges and iteration
+def range = 1..5
+range.each { num ->
+    println "Number: ${num}"
+}
+
+// Maps with various syntaxes
+def config = [
+    host: 'localhost',
+    port: 8080,
+    'timeout-ms': 5000
+]
+
+// Multiline strings with triple quotes
+def sql = """
+    SELECT *
+    FROM users
+    WHERE age > ${person.age}
+    ORDER BY name
+"""
+
+// GString expressions
+def message = "The config uses port ${config.port} on ${config.host}"
+println message
+
+// Method references and method pointers
+def toUpperCase = String.&toUpperCase
+println toUpperCase('groovy')
+
+// Spread operator
+def moreNumbers = [6, 7, 8]
+def combined = [*numbers, *moreNumbers]
+println "Combined: ${combined}"
+
+// Switch with pattern matching
+def describe(obj) {
+    switch(obj) {
+        case String:
+            return "String: ${obj}"
+        case Integer:
+            return "Integer: ${obj}"
+        case List:
+            return "List with ${obj.size()} elements"
+        default:
+            return "Unknown type"
+    }
+}
+
+println describe("hello")
+println describe(42)
+println describe([1, 2, 3])
+
+// Try-catch with multiple catch blocks
+try {
+    def result = 10 / 0
+} catch (ArithmeticException e) {
+    println "Cannot divide by zero"
+} catch (Exception e) {
+    println "General error: ${e.message}"
+} finally {
+    println "Cleanup code"
+}
+
+// Regex patterns
+def pattern = ~/\d{3}-\d{4}/
+def text = "Call me at 555-1234"
+def matcher = text =~ pattern
+if (matcher) {
+    println "Found phone number: ${matcher[0]}"
+}
+
+// Groovy truth (automatic boolean coercion)
+if (numbers) {
+    println "List is not empty"
+}
+
+if (person?.age) {
+    println "Person has a valid age"
+}
+
+// Meta-programming example
+String.metaClass.shout = { -> delegate.toUpperCase() + '!' }
+println "groovy".shout()

--- a/demo/samples/solidity.sol
+++ b/demo/samples/solidity.sol
@@ -1,0 +1,811 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts (last updated v5.5.0) (governance/Governor.sol)
+
+pragma solidity ^0.8.24;
+
+import {IERC721Receiver} from "../token/ERC721/IERC721Receiver.sol";
+import {IERC1155Receiver} from "../token/ERC1155/IERC1155Receiver.sol";
+import {EIP712} from "../utils/cryptography/EIP712.sol";
+import {SignatureChecker} from "../utils/cryptography/SignatureChecker.sol";
+import {IERC165, ERC165} from "../utils/introspection/ERC165.sol";
+import {SafeCast} from "../utils/math/SafeCast.sol";
+import {DoubleEndedQueue} from "../utils/structs/DoubleEndedQueue.sol";
+import {Address} from "../utils/Address.sol";
+import {Context} from "../utils/Context.sol";
+import {Nonces} from "../utils/Nonces.sol";
+import {Strings} from "../utils/Strings.sol";
+import {IGovernor, IERC6372} from "./IGovernor.sol";
+
+/**
+ * @dev Core of the governance system, designed to be extended through various modules.
+ *
+ * This contract is abstract and requires several functions to be implemented in various modules:
+ *
+ * - A counting module must implement {_quorumReached}, {_voteSucceeded} and {_countVote}
+ * - A voting module must implement {_getVotes}
+ * - Additionally, {votingPeriod}, {votingDelay}, and {quorum} must also be implemented
+ */
+abstract contract Governor is Context, ERC165, EIP712, Nonces, IGovernor, IERC721Receiver, IERC1155Receiver {
+    using DoubleEndedQueue for DoubleEndedQueue.Bytes32Deque;
+
+    bytes32 public constant BALLOT_TYPEHASH =
+        keccak256("Ballot(uint256 proposalId,uint8 support,address voter,uint256 nonce)");
+    bytes32 public constant EXTENDED_BALLOT_TYPEHASH = keccak256(
+        "ExtendedBallot(uint256 proposalId,uint8 support,address voter,uint256 nonce,string reason,bytes params)"
+    );
+
+    struct ProposalCore {
+        address proposer;
+        uint48 voteStart;
+        uint32 voteDuration;
+        bool executed;
+        bool canceled;
+        uint48 etaSeconds;
+    }
+
+    bytes32 private constant ALL_PROPOSAL_STATES_BITMAP = bytes32((2 ** (uint8(type(ProposalState).max) + 1)) - 1);
+    string private _name;
+
+    mapping(uint256 proposalId => ProposalCore) private _proposals;
+
+    // This queue keeps track of the governor operating on itself. Calls to functions protected by the {onlyGovernance}
+    // modifier needs to be whitelisted in this queue. Whitelisting is set in {execute}, consumed by the
+    // {onlyGovernance} modifier and eventually reset after {_executeOperations} completes. This ensures that the
+    // execution of {onlyGovernance} protected calls can only be achieved through successful proposals.
+    DoubleEndedQueue.Bytes32Deque private _governanceCall;
+
+    /**
+     * @dev Restricts a function so it can only be executed through governance proposals. For example, governance
+     * parameter setters in {GovernorSettings} are protected using this modifier.
+     *
+     * The governance executing address may be different from the Governor's own address, for example it could be a
+     * timelock. This can be customized by modules by overriding {_executor}. The executor is only able to invoke these
+     * functions during the execution of the governor's {execute} function, and not under any other circumstances. Thus,
+     * for example, additional timelock proposers are not able to change governance parameters without going through the
+     * governance protocol (since v4.6).
+     */
+    modifier onlyGovernance() {
+        _checkGovernance();
+        _;
+    }
+
+    /**
+     * @dev Sets the value for {name} and {version}
+     */
+    constructor(string memory name_) EIP712(name_, version()) {
+        _name = name_;
+    }
+
+    /**
+     * @dev Function to receive ETH that will be handled by the governor (disabled if executor is a third party contract)
+     */
+    receive() external payable virtual {
+        if (_executor() != address(this)) {
+            revert GovernorDisabledDeposit();
+        }
+    }
+
+    /// @inheritdoc IERC165
+    function supportsInterface(bytes4 interfaceId) public view virtual override(IERC165, ERC165) returns (bool) {
+        return interfaceId == type(IGovernor).interfaceId
+            || interfaceId == type(IGovernor).interfaceId ^ IGovernor.getProposalId.selector
+            || interfaceId == type(IERC1155Receiver).interfaceId || super.supportsInterface(interfaceId);
+    }
+
+    /// @inheritdoc IGovernor
+    function name() public view virtual returns (string memory) {
+        return _name;
+    }
+
+    /// @inheritdoc IGovernor
+    function version() public view virtual returns (string memory) {
+        return "1";
+    }
+
+    /**
+     * @dev See {IGovernor-hashProposal}.
+     *
+     * The proposal id is produced by hashing the ABI encoded `targets` array, the `values` array, the `calldatas` array
+     * and the descriptionHash (bytes32 which itself is the keccak256 hash of the description string). This proposal id
+     * can be produced from the proposal data which is part of the {ProposalCreated} event. It can even be computed in
+     * advance, before the proposal is submitted.
+     *
+     * Note that the chainId and the governor address are not part of the proposal id computation. Consequently, the
+     * same proposal (with same operation and same description) will have the same id if submitted on multiple governors
+     * across multiple networks. This also means that in order to execute the same operation twice (on the same
+     * governor) the proposer will have to change the description in order to avoid proposal id conflicts.
+     */
+    function hashProposal(
+        address[] memory targets,
+        uint256[] memory values,
+        bytes[] memory calldatas,
+        bytes32 descriptionHash
+    ) public pure virtual returns (uint256) {
+        return uint256(keccak256(abi.encode(targets, values, calldatas, descriptionHash)));
+    }
+
+    /// @inheritdoc IGovernor
+    function getProposalId(
+        address[] memory targets,
+        uint256[] memory values,
+        bytes[] memory calldatas,
+        bytes32 descriptionHash
+    ) public view virtual returns (uint256) {
+        return hashProposal(targets, values, calldatas, descriptionHash);
+    }
+
+    /// @inheritdoc IGovernor
+    function state(uint256 proposalId) public view virtual returns (ProposalState) {
+        // We read the struct fields into the stack at once so Solidity emits a single SLOAD
+        ProposalCore storage proposal = _proposals[proposalId];
+        bool proposalExecuted = proposal.executed;
+        bool proposalCanceled = proposal.canceled;
+
+        if (proposalExecuted) {
+            return ProposalState.Executed;
+        }
+
+        if (proposalCanceled) {
+            return ProposalState.Canceled;
+        }
+
+        uint256 snapshot = proposalSnapshot(proposalId);
+
+        if (snapshot == 0) {
+            revert GovernorNonexistentProposal(proposalId);
+        }
+
+        uint256 currentTimepoint = clock();
+
+        if (snapshot >= currentTimepoint) {
+            return ProposalState.Pending;
+        }
+
+        uint256 deadline = proposalDeadline(proposalId);
+
+        if (deadline >= currentTimepoint) {
+            return ProposalState.Active;
+        } else if (!_quorumReached(proposalId) || !_voteSucceeded(proposalId)) {
+            return ProposalState.Defeated;
+        } else if (proposalEta(proposalId) == 0) {
+            return ProposalState.Succeeded;
+        } else {
+            return ProposalState.Queued;
+        }
+    }
+
+    /// @inheritdoc IGovernor
+    function proposalThreshold() public view virtual returns (uint256) {
+        return 0;
+    }
+
+    /// @inheritdoc IGovernor
+    function proposalSnapshot(uint256 proposalId) public view virtual returns (uint256) {
+        return _proposals[proposalId].voteStart;
+    }
+
+    /// @inheritdoc IGovernor
+    function proposalDeadline(uint256 proposalId) public view virtual returns (uint256) {
+        return _proposals[proposalId].voteStart + _proposals[proposalId].voteDuration;
+    }
+
+    /// @inheritdoc IGovernor
+    function proposalProposer(uint256 proposalId) public view virtual returns (address) {
+        return _proposals[proposalId].proposer;
+    }
+
+    /// @inheritdoc IGovernor
+    function proposalEta(uint256 proposalId) public view virtual returns (uint256) {
+        return _proposals[proposalId].etaSeconds;
+    }
+
+    /// @inheritdoc IGovernor
+    function proposalNeedsQueuing(uint256) public view virtual returns (bool) {
+        return false;
+    }
+
+    /**
+     * @dev Reverts if the `msg.sender` is not the executor. In case the executor is not this contract
+     * itself, the function reverts if `msg.data` is not whitelisted as a result of an {execute}
+     * operation. See {onlyGovernance}.
+     */
+    function _checkGovernance() internal virtual {
+        if (_executor() != _msgSender()) {
+            revert GovernorOnlyExecutor(_msgSender());
+        }
+        if (_executor() != address(this)) {
+            bytes32 msgDataHash = keccak256(_msgData());
+            // loop until popping the expected operation - throw if deque is empty (operation not authorized)
+            while (_governanceCall.popFront() != msgDataHash) {}
+        }
+    }
+
+    /**
+     * @dev Amount of votes already cast passes the threshold limit.
+     */
+    function _quorumReached(uint256 proposalId) internal view virtual returns (bool);
+
+    /**
+     * @dev Is the proposal successful or not.
+     */
+    function _voteSucceeded(uint256 proposalId) internal view virtual returns (bool);
+
+    /**
+     * @dev Get the voting weight of `account` at a specific `timepoint`, for a vote as described by `params`.
+     */
+    function _getVotes(address account, uint256 timepoint, bytes memory params) internal view virtual returns (uint256);
+
+    /**
+     * @dev Register a vote for `proposalId` by `account` with a given `support`, voting `weight` and voting `params`.
+     *
+     * Note: Support is generic and can represent various things depending on the voting system used.
+     */
+    function _countVote(uint256 proposalId, address account, uint8 support, uint256 totalWeight, bytes memory params)
+        internal
+        virtual
+        returns (uint256);
+
+    /**
+     * @dev Hook that should be called every time the tally for a proposal is updated.
+     *
+     * Note: This function must run successfully. Reverts will result in the bricking of governance
+     */
+    function _tallyUpdated(uint256 proposalId) internal virtual {}
+
+    /**
+     * @dev Default additional encoded parameters used by castVote methods that don't include them
+     *
+     * Note: Should be overridden by specific implementations to use an appropriate value, the
+     * meaning of the additional params, in the context of that implementation
+     */
+    function _defaultParams() internal view virtual returns (bytes memory) {
+        return "";
+    }
+
+    /**
+     * @dev See {IGovernor-propose}. This function has opt-in frontrunning protection, described in {_isValidDescriptionForProposer}.
+     */
+    function propose(
+        address[] memory targets,
+        uint256[] memory values,
+        bytes[] memory calldatas,
+        string memory description
+    ) public virtual returns (uint256) {
+        address proposer = _msgSender();
+
+        // check description restriction
+        if (!_isValidDescriptionForProposer(proposer, description)) {
+            revert GovernorRestrictedProposer(proposer);
+        }
+
+        // check proposal threshold
+        uint256 votesThreshold = proposalThreshold();
+        if (votesThreshold > 0) {
+            uint256 proposerVotes = getVotes(proposer, clock() - 1);
+            if (proposerVotes < votesThreshold) {
+                revert GovernorInsufficientProposerVotes(proposer, proposerVotes, votesThreshold);
+            }
+        }
+
+        return _propose(targets, values, calldatas, description, proposer);
+    }
+
+    /**
+     * @dev Internal propose mechanism. Can be overridden to add more logic on proposal creation.
+     *
+     * Emits a {IGovernor-ProposalCreated} event.
+     */
+    function _propose(
+        address[] memory targets,
+        uint256[] memory values,
+        bytes[] memory calldatas,
+        string memory description,
+        address proposer
+    ) internal virtual returns (uint256 proposalId) {
+        proposalId = getProposalId(targets, values, calldatas, keccak256(bytes(description)));
+
+        if (targets.length != values.length || targets.length != calldatas.length || targets.length == 0) {
+            revert GovernorInvalidProposalLength(targets.length, calldatas.length, values.length);
+        }
+        if (_proposals[proposalId].voteStart != 0) {
+            revert GovernorUnexpectedProposalState(proposalId, state(proposalId), bytes32(0));
+        }
+
+        uint256 snapshot = clock() + votingDelay();
+        uint256 duration = votingPeriod();
+
+        ProposalCore storage proposal = _proposals[proposalId];
+        proposal.proposer = proposer;
+        proposal.voteStart = SafeCast.toUint48(snapshot);
+        proposal.voteDuration = SafeCast.toUint32(duration);
+
+        emit ProposalCreated(
+            proposalId,
+            proposer,
+            targets,
+            values,
+            new string[](targets.length),
+            calldatas,
+            snapshot,
+            snapshot + duration,
+            description
+        );
+
+        // Using a named return variable to avoid stack too deep errors
+    }
+
+    /// @inheritdoc IGovernor
+    function queue(address[] memory targets, uint256[] memory values, bytes[] memory calldatas, bytes32 descriptionHash)
+        public
+        virtual
+        returns (uint256)
+    {
+        uint256 proposalId = getProposalId(targets, values, calldatas, descriptionHash);
+
+        _validateStateBitmap(proposalId, _encodeStateBitmap(ProposalState.Succeeded));
+
+        uint48 etaSeconds = _queueOperations(proposalId, targets, values, calldatas, descriptionHash);
+
+        if (etaSeconds != 0) {
+            _proposals[proposalId].etaSeconds = etaSeconds;
+            emit ProposalQueued(proposalId, etaSeconds);
+        } else {
+            revert GovernorQueueNotImplemented();
+        }
+
+        return proposalId;
+    }
+
+    /**
+     * @dev Internal queuing mechanism. Can be overridden (without a super call) to modify the way queuing is
+     * performed (for example adding a vault/timelock).
+     *
+     * This is empty by default, and must be overridden to implement queuing.
+     *
+     * This function returns a timestamp that describes the expected ETA for execution. If the returned value is 0
+     * (which is the default value), the core will consider queueing did not succeed, and the public {queue} function
+     * will revert.
+     *
+     * NOTE: Calling this function directly will NOT check the current state of the proposal, or emit the
+     * `ProposalQueued` event. Queuing a proposal should be done using {queue}.
+     */
+    function _queueOperations(
+        uint256,
+        /*proposalId*/
+        address[] memory,
+        /*targets*/
+        uint256[] memory,
+        /*values*/
+        bytes[] memory,
+        /*calldatas*/
+        bytes32 /*descriptionHash*/
+    )
+        internal
+        virtual
+        returns (uint48)
+    {
+        return 0;
+    }
+
+    /// @inheritdoc IGovernor
+    function execute(
+        address[] memory targets,
+        uint256[] memory values,
+        bytes[] memory calldatas,
+        bytes32 descriptionHash
+    ) public payable virtual returns (uint256) {
+        uint256 proposalId = getProposalId(targets, values, calldatas, descriptionHash);
+
+        _validateStateBitmap(
+            proposalId, _encodeStateBitmap(ProposalState.Succeeded) | _encodeStateBitmap(ProposalState.Queued)
+        );
+
+        // mark as executed before calls to avoid reentrancy
+        _proposals[proposalId].executed = true;
+
+        // before execute: register governance call in queue.
+        if (_executor() != address(this)) {
+            for (uint256 i = 0; i < targets.length; ++i) {
+                if (targets[i] == address(this)) {
+                    _governanceCall.pushBack(keccak256(calldatas[i]));
+                }
+            }
+        }
+
+        _executeOperations(proposalId, targets, values, calldatas, descriptionHash);
+
+        // after execute: cleanup governance call queue.
+        if (_executor() != address(this) && !_governanceCall.empty()) {
+            _governanceCall.clear();
+        }
+
+        emit ProposalExecuted(proposalId);
+
+        return proposalId;
+    }
+
+    /**
+     * @dev Internal execution mechanism. Can be overridden (without a super call) to modify the way execution is
+     * performed (for example adding a vault/timelock).
+     *
+     * NOTE: Calling this function directly will NOT check the current state of the proposal, set the executed flag to
+     * true or emit the `ProposalExecuted` event. Executing a proposal should be done using {execute}.
+     */
+    function _executeOperations(
+        uint256,
+        /* proposalId */
+        address[] memory targets,
+        uint256[] memory values,
+        bytes[] memory calldatas,
+        bytes32 /*descriptionHash*/
+    ) internal virtual {
+        for (uint256 i = 0; i < targets.length; ++i) {
+            (bool success, bytes memory returndata) = targets[i].call{value: values[i]}(calldatas[i]);
+            Address.verifyCallResult(success, returndata);
+        }
+    }
+
+    /// @inheritdoc IGovernor
+    function cancel(
+        address[] memory targets,
+        uint256[] memory values,
+        bytes[] memory calldatas,
+        bytes32 descriptionHash
+    ) public virtual returns (uint256) {
+        // The proposalId will be recomputed in the `_cancel` call further down. However we need the value before we
+        // do the internal call, because we need to check the proposal state BEFORE the internal `_cancel` call
+        // changes it. The `getProposalId` duplication has a cost that is limited, and that we accept.
+        uint256 proposalId = getProposalId(targets, values, calldatas, descriptionHash);
+
+        address caller = _msgSender();
+        if (!_validateCancel(proposalId, caller)) revert GovernorUnableToCancel(proposalId, caller);
+
+        return _cancel(targets, values, calldatas, descriptionHash);
+    }
+
+    /**
+     * @dev Internal cancel mechanism with minimal restrictions. A proposal can be cancelled in any state other than
+     * Canceled, Expired, or Executed. Once cancelled a proposal can't be re-submitted.
+     *
+     * Emits a {IGovernor-ProposalCanceled} event.
+     */
+    function _cancel(
+        address[] memory targets,
+        uint256[] memory values,
+        bytes[] memory calldatas,
+        bytes32 descriptionHash
+    ) internal virtual returns (uint256) {
+        uint256 proposalId = getProposalId(targets, values, calldatas, descriptionHash);
+
+        _validateStateBitmap(
+            proposalId,
+            ALL_PROPOSAL_STATES_BITMAP ^ _encodeStateBitmap(ProposalState.Canceled)
+                ^ _encodeStateBitmap(ProposalState.Expired) ^ _encodeStateBitmap(ProposalState.Executed)
+        );
+
+        _proposals[proposalId].canceled = true;
+        emit ProposalCanceled(proposalId);
+
+        return proposalId;
+    }
+
+    /// @inheritdoc IGovernor
+    function getVotes(address account, uint256 timepoint) public view virtual returns (uint256) {
+        return _getVotes(account, timepoint, _defaultParams());
+    }
+
+    /// @inheritdoc IGovernor
+    function getVotesWithParams(address account, uint256 timepoint, bytes memory params)
+        public
+        view
+        virtual
+        returns (uint256)
+    {
+        return _getVotes(account, timepoint, params);
+    }
+
+    /// @inheritdoc IGovernor
+    function castVote(uint256 proposalId, uint8 support) public virtual returns (uint256) {
+        address voter = _msgSender();
+        return _castVote(proposalId, voter, support, "");
+    }
+
+    /// @inheritdoc IGovernor
+    function castVoteWithReason(uint256 proposalId, uint8 support, string calldata reason)
+        public
+        virtual
+        returns (uint256)
+    {
+        address voter = _msgSender();
+        return _castVote(proposalId, voter, support, reason);
+    }
+
+    /// @inheritdoc IGovernor
+    function castVoteWithReasonAndParams(uint256 proposalId, uint8 support, string calldata reason, bytes memory params)
+        public
+        virtual
+        returns (uint256)
+    {
+        address voter = _msgSender();
+        return _castVote(proposalId, voter, support, reason, params);
+    }
+
+    /// @inheritdoc IGovernor
+    function castVoteBySig(uint256 proposalId, uint8 support, address voter, bytes memory signature)
+        public
+        virtual
+        returns (uint256)
+    {
+        if (!_validateVoteSig(proposalId, support, voter, signature)) {
+            revert GovernorInvalidSignature(voter);
+        }
+        return _castVote(proposalId, voter, support, "");
+    }
+
+    /// @inheritdoc IGovernor
+    function castVoteWithReasonAndParamsBySig(
+        uint256 proposalId,
+        uint8 support,
+        address voter,
+        string calldata reason,
+        bytes memory params,
+        bytes memory signature
+    ) public virtual returns (uint256) {
+        if (!_validateExtendedVoteSig(proposalId, support, voter, reason, params, signature)) {
+            revert GovernorInvalidSignature(voter);
+        }
+        return _castVote(proposalId, voter, support, reason, params);
+    }
+
+    /// @dev Validate the `signature` used in {castVoteBySig} function.
+    function _validateVoteSig(uint256 proposalId, uint8 support, address voter, bytes memory signature)
+        internal
+        virtual
+        returns (bool)
+    {
+        return SignatureChecker.isValidSignatureNow(
+            voter,
+            _hashTypedDataV4(keccak256(abi.encode(BALLOT_TYPEHASH, proposalId, support, voter, _useNonce(voter)))),
+            signature
+        );
+    }
+
+    /// @dev Validate the `signature` used in {castVoteWithReasonAndParamsBySig} function.
+    function _validateExtendedVoteSig(
+        uint256 proposalId,
+        uint8 support,
+        address voter,
+        string memory reason,
+        bytes memory params,
+        bytes memory signature
+    ) internal virtual returns (bool) {
+        return SignatureChecker.isValidSignatureNow(
+            voter,
+            _hashTypedDataV4(
+                keccak256(
+                    abi.encode(
+                        EXTENDED_BALLOT_TYPEHASH,
+                        proposalId,
+                        support,
+                        voter,
+                        _useNonce(voter),
+                        keccak256(bytes(reason)),
+                        keccak256(params)
+                    )
+                )
+            ),
+            signature
+        );
+    }
+
+    /**
+     * @dev Internal vote casting mechanism: Check that the vote is pending, that it has not been cast yet, retrieve
+     * voting weight using {IGovernor-getVotes} and call the {_countVote} internal function. Uses the _defaultParams().
+     *
+     * Emits a {IGovernor-VoteCast} event.
+     */
+    function _castVote(uint256 proposalId, address account, uint8 support, string memory reason)
+        internal
+        virtual
+        returns (uint256)
+    {
+        return _castVote(proposalId, account, support, reason, _defaultParams());
+    }
+
+    /**
+     * @dev Internal vote casting mechanism: Check that the vote is pending, that it has not been cast yet, retrieve
+     * voting weight using {IGovernor-getVotes} and call the {_countVote} internal function.
+     *
+     * Emits a {IGovernor-VoteCast} event.
+     */
+    function _castVote(uint256 proposalId, address account, uint8 support, string memory reason, bytes memory params)
+        internal
+        virtual
+        returns (uint256)
+    {
+        _validateStateBitmap(proposalId, _encodeStateBitmap(ProposalState.Active));
+
+        uint256 totalWeight = _getVotes(account, proposalSnapshot(proposalId), params);
+        uint256 votedWeight = _countVote(proposalId, account, support, totalWeight, params);
+
+        if (params.length == 0) {
+            emit VoteCast(account, proposalId, support, votedWeight, reason);
+        } else {
+            emit VoteCastWithParams(account, proposalId, support, votedWeight, reason, params);
+        }
+
+        _tallyUpdated(proposalId);
+
+        return votedWeight;
+    }
+
+    /**
+     * @dev Relays a transaction or function call to an arbitrary target. In cases where the governance executor
+     * is some contract other than the governor itself, like when using a timelock, this function can be invoked
+     * in a governance proposal to recover tokens or Ether that was sent to the governor contract by mistake.
+     * Note that if the executor is simply the governor itself, use of `relay` is redundant.
+     */
+    function relay(address target, uint256 value, bytes calldata data) public payable virtual onlyGovernance {
+        (bool success, bytes memory returndata) = target.call{value: value}(data);
+        Address.verifyCallResult(success, returndata);
+    }
+
+    /**
+     * @dev Address through which the governor executes action. Will be overloaded by module that executes actions
+     * through another contract such as a timelock.
+     */
+    function _executor() internal view virtual returns (address) {
+        return address(this);
+    }
+
+    /**
+     * @dev See {IERC721Receiver-onERC721Received}.
+     * Receiving tokens is disabled if the governance executor is other than the governor itself (eg. when using with a timelock).
+     */
+    function onERC721Received(address, address, uint256, bytes memory) public virtual returns (bytes4) {
+        if (_executor() != address(this)) {
+            revert GovernorDisabledDeposit();
+        }
+        return this.onERC721Received.selector;
+    }
+
+    /**
+     * @dev See {IERC1155Receiver-onERC1155Received}.
+     * Receiving tokens is disabled if the governance executor is other than the governor itself (eg. when using with a timelock).
+     */
+    function onERC1155Received(address, address, uint256, uint256, bytes memory) public virtual returns (bytes4) {
+        if (_executor() != address(this)) {
+            revert GovernorDisabledDeposit();
+        }
+        return this.onERC1155Received.selector;
+    }
+
+    /**
+     * @dev See {IERC1155Receiver-onERC1155BatchReceived}.
+     * Receiving tokens is disabled if the governance executor is other than the governor itself (eg. when using with a timelock).
+     */
+    function onERC1155BatchReceived(address, address, uint256[] memory, uint256[] memory, bytes memory)
+        public
+        virtual
+        returns (bytes4)
+    {
+        if (_executor() != address(this)) {
+            revert GovernorDisabledDeposit();
+        }
+        return this.onERC1155BatchReceived.selector;
+    }
+
+    /**
+     * @dev Encodes a `ProposalState` into a `bytes32` representation where each bit enabled corresponds to
+     * the underlying position in the `ProposalState` enum. For example:
+     *
+     * 0x000...10000
+     *   ^^^^^^------ ...
+     *         ^----- Succeeded
+     *          ^---- Defeated
+     *           ^--- Canceled
+     *            ^-- Active
+     *             ^- Pending
+     */
+    function _encodeStateBitmap(ProposalState proposalState) internal pure returns (bytes32) {
+        return bytes32(1 << uint8(proposalState));
+    }
+
+    /**
+     * @dev Check that the current state of a proposal matches the requirements described by the `allowedStates` bitmap.
+     * This bitmap should be built using `_encodeStateBitmap`.
+     *
+     * If requirements are not met, reverts with a {GovernorUnexpectedProposalState} error.
+     */
+    function _validateStateBitmap(uint256 proposalId, bytes32 allowedStates) internal view returns (ProposalState) {
+        ProposalState currentState = state(proposalId);
+        if (_encodeStateBitmap(currentState) & allowedStates == bytes32(0)) {
+            revert GovernorUnexpectedProposalState(proposalId, currentState, allowedStates);
+        }
+        return currentState;
+    }
+
+    /**
+     * @dev Check if the proposer is authorized to submit a proposal with the given description.
+     *
+     * If the proposal description ends with `#proposer=0x???`, where `0x???` is an address written as a hex string
+     * (case insensitive), then the submission of this proposal will only be authorized to said address.
+     *
+     * This is used for frontrunning protection. By adding this pattern at the end of their proposal, one can ensure
+     * that no other address can submit the same proposal. An attacker would have to either remove or change that part,
+     * which would result in a different proposal id.
+     *
+     * If the description does not match this pattern, it is unrestricted and anyone can submit it. This includes:
+     *
+     * - If the `0x???` part is not a valid hex string.
+     * - If the `0x???` part is a valid hex string, but does not contain exactly 40 hex digits.
+     * - If it ends with the expected suffix followed by newlines or other whitespace.
+     * - If it ends with some other similar suffix, e.g. `#other=abc`.
+     * - If it does not end with any such suffix.
+     */
+    function _isValidDescriptionForProposer(address proposer, string memory description)
+        internal
+        view
+        virtual
+        returns (bool)
+    {
+        unchecked {
+            uint256 length = bytes(description).length;
+
+            // Length is too short to contain a valid proposer suffix
+            if (length < 52) {
+                return true;
+            }
+
+            // Extract what would be the `#proposer=` marker beginning the suffix
+            bytes10 marker = bytes10(_unsafeReadBytesOffset(bytes(description), length - 52));
+
+            // If the marker is not found, there is no proposer suffix to check
+            if (marker != bytes10("#proposer=")) {
+                return true;
+            }
+
+            // Check that the last 42 characters (after the marker) are a properly formatted address.
+            (bool success, address recovered) = Strings.tryParseAddress(description, length - 42, length);
+            return !success || recovered == proposer;
+        }
+    }
+
+    /**
+     * @dev Check if the `caller` can cancel the proposal with the given `proposalId`.
+     *
+     * The default implementation allows the proposal proposer to cancel the proposal during the pending state.
+     */
+    function _validateCancel(uint256 proposalId, address caller) internal view virtual returns (bool) {
+        return (state(proposalId) == ProposalState.Pending) && caller == proposalProposer(proposalId);
+    }
+
+    /// @inheritdoc IERC6372
+    function clock() public view virtual returns (uint48);
+
+    /// @inheritdoc IERC6372
+    // solhint-disable-next-line func-name-mixedcase
+    function CLOCK_MODE() public view virtual returns (string memory);
+
+    /// @inheritdoc IGovernor
+    function votingDelay() public view virtual returns (uint256);
+
+    /// @inheritdoc IGovernor
+    function votingPeriod() public view virtual returns (uint256);
+
+    /// @inheritdoc IGovernor
+    function quorum(uint256 timepoint) public view virtual returns (uint256);
+
+    /**
+     * @dev Reads a bytes32 from a bytes array without bounds checking.
+     *
+     * NOTE: making this function internal would mean it could be used with memory unsafe offset, and marking the
+     * assembly block as such would prevent some optimizations.
+     */
+    function _unsafeReadBytesOffset(bytes memory buffer, uint256 offset) private pure returns (bytes32 value) {
+        // This is not memory safe in the general case, but all calls to this private function are within bounds.
+        assembly ("memory-safe") {
+            value := mload(add(add(buffer, 0x20), offset))
+        }
+    }
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1767364772,
+        "narHash": "sha256-fFUnEYMla8b7UKjijLnMe+oVFOz6HjijGGNS1l7dYaQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "16c7794d0a28b5a37904d55bcca36003b9109aaa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,45 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      forAllSystems = nixpkgs.lib.genAttrs nixpkgs.lib.systems.flakeExposed;
+    in
+    {
+      devShells = forAllSystems (system:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+          };
+        in
+        {
+          default = pkgs.mkShell {
+            buildInputs = with pkgs; [
+              binaryen
+              cargo-nextest
+              jq
+              pnpm
+              rustup
+              tree-sitter
+              wasm-bindgen-cli
+              wasm-pack
+              wild-unwrapped
+            ];
+            shellHook = ''
+              rustup toolchain install stable
+              rustup target add wasm32-unknown-unknown
+              rustup component add clippy rustfmt
+              rustup toolchain install nightly
+              rustup target add wasm32-unknown-unknown --toolchain nightly
+              rustup component add rust-src --toolchain nightly
+            '';
+
+            CARGO_TARGET_X86_64_LINUX_UNKNOWN_GNU_RUSTFLAGS = "-C link-arg=--ld-path=${pkgs.wild}/bin/wild";
+            CARGO_TARGET_X86_64_LINUX_UNKNOWN_GNU_LINKER = "clang";
+          };
+        }
+      );
+    };
+}

--- a/langs/group-pine/solidity/def/arborium.kdl
+++ b/langs/group-pine/solidity/def/arborium.kdl
@@ -1,0 +1,35 @@
+// Repository information (REQUIRED)
+repo "https://github.com/JoranHonig/tree-sitter-solidity"
+commit "4e938a46c7030dd001bc99e1ac0f0c750ac98254"  // Full commit hash from the grammar repo
+license "MIT"       // License of the grammar repository
+
+grammar {
+    // Basic identification (REQUIRED)
+    id "solidity"                // Unique identifier (lowercase, no spaces)
+    name "Solidity"              // Display name
+    tag "code"                   // Category: "code", "data", "markup", "config"
+    tier 2                       // Quality tier: 1 (best) to 5 (experimental)
+
+    // Technical flags
+    has-scanner #false           // Set to #true if scanner.c exists
+    generate-component #true     // Set to #true to include in WASM builds
+
+    // Visual representation
+    icon "devicon-plain:solidity"  // Icon identifier (from iconify.design)
+    aliases "sol"                  // File extensions (space-separated)
+
+    // Metadata (REQUIRED for documentation)
+    inventor "Gavin Wood"
+    year 2014
+    description "Solidity is a programming language for implementing smart contracts on various blockchain platforms, most notably, Ethereum."
+    link "https://en.wikipedia.org/wiki/Solidity"
+    trivia "Solidity doesn't have native support for floating-point numbers by design. Floating-point arithmetic can produce slightly different results on different machines, which would break blockchain consensus, so everything is done with integers and fixed-point math."
+
+    // Sample files (at least one REQUIRED)
+    sample {
+        path "samples/example.sol"
+        description "Typical contract found in the widely used OpenZeppelin library, making use of multiple language features like inline assembly and inheritance"
+        link "https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/governance/Governor.sol"
+        license "MIT"
+    }
+}

--- a/langs/group-pine/solidity/def/grammar/grammar.js
+++ b/langs/group-pine/solidity/def/grammar/grammar.js
@@ -1,0 +1,1327 @@
+// Precedence is used by the parser to determine which rule to apply when there are two rules that can be applied.
+// We use the PREC dict to globally define rule precedence
+// [N] corresponds to precedence table at https://docs.soliditylang.org/en/v0.8.24/cheatsheet.html#order-of-precedence-of-operators
+const PREC = {
+	COMMENT: 1,
+	STRING: 2,
+
+	COMMA: -1, // [15] Comma operator
+	OBJECT: -1,
+	USER_TYPE: 1,
+	DECLARATION: 1,
+	TERNARY: 0, // [14] Ternary operator
+	ASSIGN: 0, // [14] Assignment operators
+	LOGICAL_OR: 1, // [13] Logical OR
+	LOGICAL_AND: 2, // [12] Logical AND
+	REL_EQ: 3, // [11] Equality operators
+	REL_INEQ: 4, // [10] Inequality operators
+	BITWISE_OR: 5, // [9] Bitwise OR
+	BITWISE_XOR: 6, // [8] Bitwise XOR
+	BITWISE_AND: 7, // [7] Bitwise AND
+	BITWISE_SHIFT: 8, // [6] Bitwise shift operators
+	PLUS: 9, // [5] Addition and substraction
+	TIMES: 10, // [4] Multiplication, division and modulo
+	EXP: 11, // [3] Exponentiation
+	PREFIX_UNARY: 12, // [2]
+	POSTFIX_UNARY: 13, // [1]
+	CALL: 13, // ??
+	REVERT: 13, // ??
+};
+
+// The following is the core grammar for Solidity. It accepts Solidity smart contracts between the versions 0.4.x and 0.8.x.
+module.exports = grammar({
+	name: "solidity",
+
+	// Extras is an array of tokens that is allowed anywhere in the document.
+	extras: ($) => [
+		// Allow comments to be placed anywhere in the file
+		$.comment,
+		// Allow characters such as whitespaces to be placed anywhere in the file
+		/[\s\uFEFF\u2060\u200B\u00A0]/,
+	],
+
+	// The word token allows tree-sitter to appropriately handle scenario's where an identifier includes a keyword.
+	// Documentation: https://tree-sitter.github.io/tree-sitter/creating-parsers#keywords
+	word: ($) => $.identifier,
+
+	conflicts: ($) => [
+		// The following conflicts are all due to the array type and array access expression ambiguity
+		[$._primary_expression, $.type_name],
+		[$._primary_expression, $._identifier_path],
+		[$._primary_expression, $.member_expression, $._identifier_path],
+		[$.member_expression, $._identifier_path],
+		[$.layout_specifier, $.struct_expression],
+		[$._nameless_parameter, $.parameter],
+
+		[$._primary_expression, $.type_cast_expression],
+		[$.variable_declaration_tuple, $.tuple_expression],
+
+		[$._yul_expression, $.yul_assignment],
+		// Ambiguity: identifier ':'
+		[$.yul_label, $.yul_identifier],
+
+		// This is to deal with ambiguities arising from different fallback styles
+		[$.fallback_receive_definition, $._function_type],
+	],
+
+	rules: {
+		//  -- [ Program ] --
+		source_file: ($) => seq(repeat($._source_unit)),
+
+		//  -- [ Source Element ] --
+		_source_unit: ($) => choice($._directive, $._declaration),
+
+		//  -- [ Directives ] --
+		_directive: ($) => choice($.pragma_directive, $.import_directive),
+
+		// Pragma
+		pragma_directive: ($) =>
+			seq(
+				"pragma",
+				choice($.solidity_pragma_token, $.any_pragma_token),
+				$._semicolon,
+			),
+
+		solidity_pragma_token: ($) =>
+			prec(
+				10,
+				seq(
+					$._solidity,
+					repeat(
+						seq(
+							field("version_constraint", $._pragma_version_constraint),
+							optional(choice("||", "-")),
+						),
+					),
+				),
+			),
+
+		any_pragma_token: ($) => seq($.identifier, $.pragma_value),
+
+		_solidity: ($) => prec(1, "solidity"),
+		pragma_value: ($) => prec(0, /[^;]+/),
+
+		_pragma_version_constraint: ($) =>
+			seq(optional($.solidity_version_comparison_operator), $.solidity_version),
+		solidity_version: ($) => /"?\.? ?(\d|\*)+(\. ?(\d|\*)+ ?(\.(\d|\*)+)?)?"?/,
+		solidity_version_comparison_operator: ($) =>
+			choice("<=", "<", "^", ">", ">=", "~", "="),
+
+		// Import
+		import_directive: ($) =>
+			seq(
+				"import",
+				choice($._source_import, seq($._import_clause, $._from_clause)),
+				$._semicolon,
+			),
+
+		_source_import: ($) =>
+			seq(field("source", $.string), optional($._import_alias)),
+
+		_import_clause: ($) => choice($._single_import, $._multiple_import),
+
+		_from_clause: ($) => seq("from", field("source", $.string)),
+
+		_single_import: ($) =>
+			seq(
+				choice("*", field("import_name", $.identifier)),
+				optional($._import_alias),
+			),
+
+		_multiple_import: ($) => seq("{", commaSep($._import_declaration), "}"),
+
+		_import_declaration: ($) =>
+			seq(field("import_name", $.identifier), optional($._import_alias)),
+
+		_import_alias: ($) => seq("as", field("alias", $.identifier)),
+
+		//  -- [ Declarations ] --
+		_declaration: ($) =>
+			choice(
+				$.contract_declaration,
+				$.interface_declaration,
+				$.error_declaration,
+				$.library_declaration,
+				$.struct_declaration,
+				$.enum_declaration,
+				$.function_definition,
+				$.constant_variable_declaration,
+				$.user_defined_type_definition,
+				$.event_definition,
+				$.using_directive,
+			),
+
+		user_defined_type_definition: ($) =>
+			seq(
+				"type",
+				field("name", $.identifier),
+				"is",
+				$.primitive_type,
+				$._semicolon,
+			),
+
+		constant_variable_declaration: ($) =>
+			seq(
+				field("type", $.type_name),
+				"constant",
+				field("name", $.identifier),
+				"=",
+				field("value", $.expression),
+				$._semicolon,
+			),
+
+		// Contract Declarations
+		contract_declaration: ($) =>
+			seq(
+				optional("abstract"),
+				"contract",
+				field("name", $.identifier),
+				repeat(choice($._class_heritage, $.layout_specifier)),
+				field("body", $.contract_body),
+			),
+
+		error_declaration: ($) =>
+			seq(
+				"error",
+				field("name", $.identifier),
+				"(",
+				commaSep($.error_parameter),
+				")",
+				$._semicolon,
+			),
+
+		error_parameter: ($) =>
+			seq(field("type", $.type_name), field("name", optional($.identifier))),
+
+		interface_declaration: ($) =>
+			seq(
+				"interface",
+				field("name", $.identifier),
+				optional($._class_heritage),
+				field("body", $.contract_body),
+			),
+
+		library_declaration: ($) =>
+			seq(
+				"library",
+				field("name", $.identifier),
+				field("body", $.contract_body),
+			),
+
+		_class_heritage: ($) => seq("is", commaSep1($.inheritance_specifier)),
+
+		layout_specifier: ($) => seq("layout", "at", $.expression),
+
+		inheritance_specifier: ($) =>
+			seq(
+				field("ancestor", $.user_defined_type),
+				optional(field("ancestor_arguments", $._call_arguments)),
+			),
+
+		contract_body: ($) => seq("{", repeat($._contract_member), "}"),
+
+		_contract_member: ($) =>
+			choice(
+				$.function_definition,
+				$.modifier_definition,
+				$.error_declaration,
+				$.state_variable_declaration,
+				$.struct_declaration,
+				$.enum_declaration,
+				$.event_definition,
+				$.using_directive,
+				$.constructor_definition,
+				$.fallback_receive_definition,
+				$.user_defined_type_definition,
+			),
+
+		struct_declaration: ($) =>
+			seq("struct", field("name", $.identifier), field("body", $.struct_body)),
+
+		struct_member: ($) =>
+			seq(
+				field("type", $.type_name),
+				field("name", $.identifier),
+				$._semicolon,
+			),
+
+		struct_body: ($) => seq("{", repeat1($.struct_member), "}"),
+
+		enum_declaration: ($) =>
+			seq("enum", field("name", $.identifier), field("body", $.enum_body)),
+
+		enum_body: ($) =>
+			seq("{", commaSep(alias($.identifier, $.enum_value)), "}"),
+
+		event_definition: ($) =>
+			seq(
+				"event",
+				field("name", $.identifier),
+				$._event_parameter_list,
+				optional("anonymous"),
+				$._semicolon,
+			),
+
+		_event_parameter_list: ($) => seq("(", commaSep($.event_parameter), ")"),
+
+		event_parameter: ($) =>
+			seq(
+				field("type", $.type_name),
+				optional("indexed"),
+				optional(field("name", $.identifier)),
+			),
+
+		user_definable_operator: ($) =>
+			choice(
+				"&",
+				"~",
+				"|",
+				"^",
+				"+",
+				"-",
+				"/",
+				"%",
+				"*",
+				"-",
+				"==",
+				">",
+				">=",
+				"<",
+				"<=",
+				"!=",
+			),
+
+		using_directive: ($) =>
+			seq(
+				"using",
+				choice(
+					alias($.user_defined_type, $.type_alias),
+					seq("{", commaSep1($.using_alias), "}"),
+				),
+				"for",
+				field("source", choice($.any_source_type, $.type_name)),
+				optional("global"),
+				$._semicolon,
+			),
+
+		using_alias: ($) =>
+			seq($.user_defined_type, optional(seq("as", $.user_definable_operator))),
+
+		any_source_type: ($) => "*",
+
+		// -- [ Statements ] --
+		statement: ($) =>
+			choice(
+				$.block_statement,
+				$.expression_statement,
+				$.variable_declaration_statement,
+				$.if_statement,
+				$.for_statement,
+				$.while_statement,
+				$.do_while_statement,
+				$.continue_statement,
+				$.break_statement,
+				$.try_statement,
+				$.return_statement,
+				$.emit_statement,
+				$.assembly_statement,
+				$.revert_statement,
+			),
+
+		assembly_statement: ($) =>
+			seq(
+				"assembly",
+				optional('"evmasm"'),
+				optional($.assembly_flags),
+				"{",
+				repeat($._yul_statement),
+				"}",
+			),
+
+		assembly_flags: ($) => seq("(", commaSep($.string), ")"),
+
+		// -- [ Yul ] --
+		_yul_statement: ($) =>
+			choice(
+				$.yul_block,
+				$.yul_variable_declaration,
+				$.yul_assignment,
+				$.yul_function_call,
+				$.yul_if_statement,
+				$.yul_for_statement,
+				$.yul_switch_statement,
+				$.yul_leave,
+				$.yul_break,
+				$.yul_continue,
+				$.yul_function_definition,
+				$.yul_label,
+				$._yul_literal,
+			),
+
+		yul_label: ($) => seq($.identifier, ":"),
+		yul_leave: ($) => "leave",
+		yul_break: ($) => "break",
+		yul_continue: ($) => "continue",
+
+		yul_identifier: ($) => $.identifier, ///[a-zA-Z$_]+/,
+		_yul_expression: ($) =>
+			choice($.yul_path, $.yul_function_call, $._yul_literal),
+		yul_path: ($) => prec.left(dotSep1($.yul_identifier)),
+
+		// -- Yul Literals --
+		_yul_literal: ($) =>
+			choice(
+				$.yul_decimal_number,
+				$.yul_string_literal,
+				$.yul_hex_number,
+				$.yul_boolean,
+				$.yul_hex_string_literal,
+			),
+		yul_decimal_number: ($) => /0|([1-9][0-9]*)/,
+		yul_string_literal: ($) => $.string,
+		yul_hex_number: ($) => /0x[0-9A-Fa-f]*/,
+		yul_boolean: ($) => choice("true", "false"),
+		yul_hex_string_literal: ($) =>
+			seq(
+				"hex",
+				choice(
+					seq('"', optional(optionalDashSeparation($._hex_digit)), '"'),
+					seq("'", optional(optionalDashSeparation($._hex_digit)), "'"),
+				),
+			),
+
+		// -- Yul Statements --
+		yul_block: ($) => seq("{", repeat($._yul_statement), "}"),
+		yul_variable_declaration: ($) =>
+			prec.left(
+				PREC.DECLARATION,
+				choice(
+					seq(
+						"let",
+						field("left", $.yul_identifier),
+						optional(seq(":=", field("right", $._yul_expression))),
+					),
+					seq(
+						"let",
+						field(
+							"left",
+							choice(
+								commaSep1($.yul_identifier),
+								seq("(", commaSep1($.yul_identifier), ")"),
+							),
+						),
+						optional(seq(":=", field("right", $.yul_function_call))),
+					),
+				),
+			),
+		_yul_assignment_operator: ($) => choice(":=", seq(":", "=")),
+		yul_assignment: ($) =>
+			prec.left(
+				PREC.ASSIGN,
+				choice(
+					seq($.yul_path, $._yul_assignment_operator, $._yul_expression),
+					seq(
+						commaSep1($.yul_path),
+						optional(seq($._yul_assignment_operator, $.yul_function_call)),
+					),
+				),
+			),
+		yul_function_call: ($) =>
+			choice(
+				seq(
+					field("function", choice($.yul_identifier, $.yul_evm_builtin)),
+					"(",
+					commaSep($._yul_expression),
+					")",
+				),
+				field("function", $.yul_evm_builtin),
+			),
+		yul_if_statement: ($) => seq("if", $._yul_expression, $.yul_block),
+		yul_for_statement: ($) =>
+			seq("for", $.yul_block, $._yul_expression, $.yul_block, $.yul_block),
+		yul_switch_statement: ($) =>
+			seq(
+				"switch",
+				$._yul_expression,
+				choice(
+					seq("default", $.yul_block),
+					seq(
+						repeat1(seq("case", $._yul_literal, $.yul_block)),
+						optional(seq("default", $.yul_block)),
+					),
+				),
+			),
+		yul_function_definition: ($) =>
+			seq(
+				"function",
+				$.yul_identifier,
+				"(",
+				commaSep($.yul_identifier),
+				")",
+				optional(seq("->", commaSep1($.yul_identifier))),
+				$.yul_block,
+			),
+
+		yul_evm_builtin: ($) =>
+			prec(
+				1,
+				choice(
+					"stop",
+					"add",
+					"sub",
+					"mul",
+					"div",
+					"sdiv",
+					"mod",
+					"smod",
+					"exp",
+					"not",
+					"lt",
+					"gt",
+					"slt",
+					"sgt",
+					"eq",
+					"iszero",
+					"and",
+					"or",
+					"xor",
+					"byte",
+					"shl",
+					"shr",
+					"sar",
+					"addmod",
+					"mulmod",
+					"signextend",
+					"keccak256",
+					"pop",
+					"mload",
+					"mcopy",
+					"tload",
+					"tstore",
+					"mstore",
+					"mstore8",
+					"sload",
+					"sstore",
+					"msize",
+					"gas",
+					"address",
+					"balance",
+					"selfbalance",
+					"caller",
+					"callvalue",
+					"calldataload",
+					"calldatasize",
+					"calldatacopy",
+					"extcodesize",
+					"extcodecopy",
+					"returndatasize",
+					"returndatacopy",
+					"extcodehash",
+					"create",
+					"create2",
+					"call",
+					"callcode",
+					"delegatecall",
+					"staticcall",
+					"return",
+					"revert",
+					"selfdestruct",
+					"invalid",
+					"log0",
+					"log1",
+					"log2",
+					"log3",
+					"log4",
+					"chainid",
+					"origin",
+					"gasprice",
+					"blockhash",
+					"blobhash",
+					"basefee",
+					"blobfee",
+					"coinbase",
+					"timestamp",
+					"number",
+					"difficulty",
+					"gaslimit",
+					"prevrandao",
+					"blobbasefee",
+					"blobfee",
+				),
+			),
+
+		// -- [ Statements ] --
+		unchecked: ($) => "unchecked",
+		block_statement: ($) =>
+			seq(optional($.unchecked), "{", repeat($.statement), "}"),
+		variable_declaration_statement: ($) =>
+			prec(
+				1,
+				seq(
+					choice(
+						seq(
+							$.variable_declaration,
+							optional(seq("=", field("value", $.expression))),
+						),
+						seq(
+							$.variable_declaration_tuple,
+							"=",
+							field("value", $.expression),
+						),
+					),
+					$._semicolon,
+				),
+			),
+
+		variable_declaration: ($) =>
+			seq(
+				field("type", $.type_name),
+				field("location", optional(choice("memory", "storage", "calldata"))),
+				field("name", $.identifier),
+			),
+
+		variable_declaration_tuple: ($) =>
+			prec(
+				3,
+				choice(
+					seq("(", commaSep(optional($.variable_declaration)), ")"),
+					seq("var", "(", commaSep(optional($.identifier)), ")"),
+				),
+			),
+
+		expression_statement: ($) => seq($.expression, $._semicolon),
+
+		if_statement: ($) =>
+			prec.right(
+				seq(
+					"if",
+					"(",
+					field("condition", $.expression),
+					")",
+					field("body", $.statement),
+					field("else", optional(seq("else", field("body", $.statement)))),
+				),
+			),
+
+		for_statement: ($) =>
+			seq(
+				"for",
+				"(",
+				field(
+					"initial",
+					choice(
+						$.variable_declaration_statement,
+						$.expression_statement,
+						$._semicolon,
+					),
+				),
+				field("condition", choice($.expression_statement, $._semicolon)),
+				field("update", optional($.expression)),
+				")",
+				field("body", $.statement),
+			),
+
+		while_statement: ($) =>
+			seq(
+				"while",
+				"(",
+				field("condition", $.expression),
+				")",
+				field("body", $.statement),
+			),
+		do_while_statement: ($) =>
+			seq(
+				"do",
+				field("body", $.statement),
+				"while",
+				"(",
+				field("condition", $.expression),
+				")",
+				$._semicolon,
+			),
+		continue_statement: ($) => seq("continue", $._semicolon),
+		break_statement: ($) => seq("break", $._semicolon),
+
+		revert_statement: ($) =>
+			prec(
+				PREC.REVERT,
+				seq(
+					"revert",
+					optional(field("error", $.expression)),
+					optional(alias($._call_arguments, $.revert_arguments)),
+					$._semicolon,
+				),
+			),
+
+		try_statement: ($) =>
+			seq(
+				"try",
+				field("attempt", $.expression),
+				optional(seq("returns", $._parameter_list)),
+				field("body", $.block_statement),
+				repeat1($.catch_clause),
+			),
+
+		catch_clause: ($) =>
+			seq(
+				"catch",
+				optional(seq(optional($.identifier), $._parameter_list)),
+				field("body", $.block_statement),
+			),
+
+		return_statement: ($) =>
+			seq("return", optional($.expression), $._semicolon),
+
+		emit_statement: ($) =>
+			seq("emit", field("name", $.expression), $._call_arguments, $._semicolon),
+
+		//  -- [ Definitions ] --
+
+		// Definitions
+		state_variable_declaration: ($) =>
+			seq(
+				field("type", $.type_name),
+				repeat(
+					choice(
+						field("visibility", $.visibility), // FIXME: this also allows external
+						"constant",
+						$.override_specifier,
+						$.immutable,
+						field("location", $.state_location),
+					),
+				),
+				field("name", $.identifier),
+				optional(seq("=", field("value", $.expression))),
+				$._semicolon,
+			),
+		visibility: ($) => choice("public", "internal", "private", "external"),
+
+		state_mutability: ($) => choice("pure", "view", "payable"),
+
+		state_location: ($) => choice("transient"),
+
+		immutable: ($) => "immutable",
+
+		override_specifier: ($) =>
+			seq("override", optional(seq("(", commaSep1($.user_defined_type), ")"))),
+
+		modifier_definition: ($) =>
+			seq(
+				"modifier",
+				field("name", $.identifier),
+				optional($._parameter_list),
+				repeat(choice($.virtual, $.override_specifier)),
+				choice($._semicolon, field("body", $.function_body)),
+			),
+
+		constructor_definition: ($) =>
+			seq(
+				"constructor",
+				$._parameter_list,
+				repeat(
+					choice(
+						$.modifier_invocation,
+						"payable",
+						choice("internal", "public"),
+					),
+				),
+				field("body", $.function_body),
+			),
+
+		fallback_receive_definition: ($) =>
+			seq(
+				choice(
+					seq(
+						// optional("function"),
+						choice("fallback", "receive", "function"),
+					),
+					"function",
+				),
+				// #todo: only fallback should get arguments
+				$._parameter_list,
+				// FIXME: We use repeat to allow for unorderedness. However, this means that the parser
+				// accepts more than just the solidity language. The same problem exists for other definition rules.
+				repeat(
+					choice(
+						$.visibility,
+						$.modifier_invocation,
+						$.state_mutability,
+						$.virtual,
+						$.override_specifier,
+					),
+				),
+				optional(seq("returns", $._parameter_list)),
+				choice($._semicolon, field("body", $.function_body)),
+			),
+
+		function_definition: ($) =>
+			seq(
+				"function",
+				field("name", $.identifier),
+				$._parameter_list,
+				repeat(
+					choice(
+						$.modifier_invocation,
+						$.visibility,
+						$.state_mutability,
+						$.virtual,
+						$.override_specifier,
+					),
+				),
+				field("return_type", optional($.return_type_definition)),
+				choice($._semicolon, field("body", $.function_body)),
+			),
+
+		return_type_definition: ($) => seq("returns", $._parameter_list),
+
+		virtual: ($) => "virtual",
+		modifier_invocation: ($) =>
+			seq($._identifier_path, optional($._call_arguments)),
+
+		_call_arguments: ($) => prec(4, seq("(", commaSep($.call_argument), ")")),
+
+		call_argument: ($) =>
+			choice($.expression, seq("{", commaSep($.call_struct_argument), "}")),
+		call_struct_argument: ($) =>
+			seq(field("name", $.identifier), ":", field("value", $.expression)),
+
+		function_body: ($) => seq("{", repeat($.statement), "}"),
+
+		// Expressions
+		expression: ($) =>
+			choice(
+				$.binary_expression,
+				$.unary_expression,
+				$.update_expression,
+				$.call_expression,
+				// TODO: $.function_call_options_expression,
+				$.payable_conversion_expression,
+				$.meta_type_expression,
+				$._primary_expression,
+				$.struct_expression,
+				$.ternary_expression,
+				$.type_cast_expression,
+			),
+
+		_primary_expression: ($) =>
+			choice(
+				$.parenthesized_expression,
+				$.member_expression,
+				$.array_access,
+				$.slice_access,
+				$.primitive_type,
+				$.assignment_expression,
+				$.augmented_assignment_expression,
+				$.user_defined_type,
+				$.tuple_expression,
+				$.inline_array_expression,
+				$.identifier,
+				$._literal,
+				$.new_expression,
+			),
+
+		// TODO: back this up with official documentation
+		type_cast_expression: ($) =>
+			prec.left(seq($.primitive_type, $._call_arguments)),
+
+		ternary_expression: ($) =>
+			prec.left(seq($.expression, "?", $.expression, ":", $.expression)),
+
+		// TODO: make sure call arguments are part of solidity
+		new_expression: ($) =>
+			prec.left(
+				seq("new", field("name", $.type_name), optional($._call_arguments)),
+			),
+
+		tuple_expression: ($) =>
+			prec(1, seq("(", commaSep(optional($.expression)), ")")),
+
+		inline_array_expression: ($) => seq("[", commaSep($.expression), "]"),
+
+		binary_expression: ($) =>
+			choice(
+				...[
+					// [13] Logical OR
+					["||", PREC.LOGICAL_OR],
+					// [12] Logical AND
+					["&&", PREC.LOGICAL_AND],
+					// [11] Equality operators
+					["==", PREC.REL_EQ],
+					["!=", PREC.REL_EQ],
+					// [10] Inequality operators
+					["<", PREC.REL_INEQ],
+					[">", PREC.REL_INEQ],
+					["<=", PREC.REL_INEQ],
+					[">=", PREC.REL_INEQ],
+					// [9] Bitwise OR
+					["|", PREC.BITWISE_OR],
+					// [8] Bitwise XOR
+					["^", PREC.BITWISE_XOR],
+					// [7] Bitwise AND
+					["&", PREC.BITWISE_AND],
+					// [6] Bitwise shift operators
+					["<<", PREC.BITWISE_SHIFT],
+					[">>", PREC.BITWISE_SHIFT],
+					// [5] Addition and subtraction
+					["+", PREC.PLUS],
+					["-", PREC.PLUS],
+					// [4] Multiplication, division and modulo
+					["*", PREC.TIMES],
+					["/", PREC.TIMES],
+					["%", PREC.TIMES],
+					// [3] Exponentiation
+					["**", PREC.EXP],
+				].map(([operator, precedence]) =>
+					prec.left(
+						precedence,
+						seq(
+							field("left", $.expression),
+							field("operator", operator),
+							field("right", $.expression),
+						),
+					),
+				),
+			),
+
+		unary_expression: ($) =>
+			choice(
+				...[
+					// [2] Unary minus
+					["-", PREC.PREFIX_UNARY],
+					// [2] Unary operations
+					["delete", PREC.PREFIX_UNARY],
+					// [2] Bitwise NOT
+					["!", PREC.PREFIX_UNARY],
+					// [2] Bitwise NOT
+					["~", PREC.PREFIX_UNARY],
+				].map(([operator, precedence]) =>
+					prec.left(
+						precedence,
+						seq(field("operator", operator), field("argument", $.expression)),
+					),
+				),
+			),
+
+		update_expression: ($) =>
+			choice(
+				prec.left(
+					PREC.POSTFIX_UNARY,
+					seq(
+						field("argument", $.expression),
+						field("operator", choice("++", "--")),
+					),
+				),
+				prec.left(
+					PREC.PREFIX_UNARY,
+					seq(
+						field("operator", choice("++", "--")),
+						field("argument", $.expression),
+					),
+				),
+			),
+
+		member_expression: ($) =>
+			prec.dynamic(
+				1,
+				seq(
+					field("object", choice($.expression, $.identifier)),
+					".",
+					field("property", $.identifier),
+				),
+			),
+
+		array_access: ($) =>
+			seq(
+				field("base", $.expression),
+				"[",
+				optional(field("index", $.expression)),
+				"]",
+			),
+
+		slice_access: ($) =>
+			seq(
+				field("base", $.expression),
+				"[",
+				optional(field("from", $.expression)),
+				":",
+				optional(field("to", $.expression)),
+				"]",
+			),
+
+		struct_expression: ($) =>
+			seq(
+				field("type", $.expression),
+				"{",
+				commaSep($.struct_field_assignment),
+				"}",
+			),
+
+		struct_field_assignment: ($) =>
+			seq(field("name", $.identifier), ":", field("value", $.expression)),
+
+		parenthesized_expression: ($) => prec(2, seq("(", $.expression, ")")),
+
+		assignment_expression: ($) =>
+			prec.right(
+				PREC.ASSIGN,
+				seq(field("left", $.expression), "=", field("right", $.expression)),
+			),
+
+		augmented_assignment_expression: ($) =>
+			prec.right(
+				PREC.ASSIGN,
+				seq(
+					field("left", $.expression),
+					choice("+=", "-=", "*=", "/=", "%=", "^=", "&=", "|=", ">>=", "<<="),
+					field("right", $.expression),
+				),
+			),
+
+		call_expression: ($) =>
+			prec.right(
+				PREC.CALL,
+				seq(field("function", $.expression), $._call_arguments),
+			),
+
+		payable_conversion_expression: ($) => seq("payable", $._call_arguments),
+		meta_type_expression: ($) => seq("type", "(", $.type_name, ")"),
+
+		type_name: ($) =>
+			choice(
+				$.primitive_type,
+				$.user_defined_type,
+				$._mapping,
+				$._array_type,
+				$._function_type,
+			),
+
+		_array_type: ($) =>
+			prec(1, seq($.type_name, "[", optional($.expression), "]")),
+
+		_function_type: ($) =>
+			prec.right(
+				seq(
+					"function",
+					field("parameters", $._parameter_list),
+					repeat(choice($.visibility, $.state_mutability)),
+					optional($._return_parameters),
+				),
+			),
+
+		_parameter_list: ($) => seq("(", commaSep($.parameter), ")"),
+
+		_return_parameters: ($) =>
+			seq(
+				"returns",
+				"(",
+				commaSep1(alias($._nameless_parameter, $.return_parameter)),
+				")",
+			),
+
+		_nameless_parameter: ($) =>
+			seq(
+				field("type", $.type_name),
+				field("location", optional($._storage_location)),
+			),
+
+		parameter: ($) =>
+			seq(
+				field("type", $.type_name),
+				optional(field("location", $._storage_location)),
+				optional(field("name", $.identifier)),
+			),
+
+		_storage_location: ($) => choice("memory", "storage", "calldata"),
+
+		user_defined_type: ($) => $._identifier_path,
+
+		_identifier_path: ($) => prec.left(dotSep1($.identifier)),
+
+		_mapping: ($) =>
+			seq(
+				"mapping",
+				"(",
+				field("key_type", $._mapping_key),
+				optional(field("key_identifier", $.identifier)),
+				"=>",
+				field("value_type", $.type_name),
+				optional(field("value_identifier", $.identifier)),
+				")",
+			),
+
+		_mapping_key: ($) => choice($.primitive_type, $.user_defined_type),
+
+		primitive_type: ($) =>
+			prec.left(
+				choice(
+					seq("address", optional("payable")),
+					"bool",
+					"string",
+					"var",
+					$._int,
+					$._uint,
+					$._bytes,
+					$._fixed,
+					$._ufixed,
+				),
+			),
+
+		_int: ($) =>
+			choice(
+				"int",
+				"int8",
+				"int16",
+				"int24",
+				"int32",
+				"int40",
+				"int48",
+				"int56",
+				"int64",
+				"int72",
+				"int80",
+				"int88",
+				"int96",
+				"int104",
+				"int112",
+				"int120",
+				"int128",
+				"int136",
+				"int144",
+				"int152",
+				"int160",
+				"int168",
+				"int176",
+				"int184",
+				"int192",
+				"int200",
+				"int208",
+				"int216",
+				"int224",
+				"int232",
+				"int240",
+				"int248",
+				"int256",
+			),
+		_uint: ($) =>
+			choice(
+				"uint",
+				"uint8",
+				"uint16",
+				"uint24",
+				"uint32",
+				"uint40",
+				"uint48",
+				"uint56",
+				"uint64",
+				"uint72",
+				"uint80",
+				"uint88",
+				"uint96",
+				"uint104",
+				"uint112",
+				"uint120",
+				"uint128",
+				"uint136",
+				"uint144",
+				"uint152",
+				"uint160",
+				"uint168",
+				"uint176",
+				"uint184",
+				"uint192",
+				"uint200",
+				"uint208",
+				"uint216",
+				"uint224",
+				"uint232",
+				"uint240",
+				"uint248",
+				"uint256",
+			),
+		_bytes: ($) =>
+			choice(
+				"byte",
+				"bytes",
+				"bytes1",
+				"bytes2",
+				"bytes3",
+				"bytes4",
+				"bytes5",
+				"bytes6",
+				"bytes7",
+				"bytes8",
+				"bytes9",
+				"bytes10",
+				"bytes11",
+				"bytes12",
+				"bytes13",
+				"bytes14",
+				"bytes15",
+				"bytes16",
+				"bytes17",
+				"bytes18",
+				"bytes19",
+				"bytes20",
+				"bytes21",
+				"bytes22",
+				"bytes23",
+				"bytes24",
+				"bytes25",
+				"bytes26",
+				"bytes27",
+				"bytes28",
+				"bytes29",
+				"bytes30",
+				"bytes31",
+				"bytes32",
+			),
+
+		_fixed: ($) => choice("fixed", /fixed([0-9]+)x([0-9]+)/),
+		_ufixed: ($) => choice("ufixed", /ufixed([0-9]+)x([0-9]+)/),
+
+		_semicolon: ($) => ";",
+
+		identifier: ($) => /[a-zA-Z$_][a-zA-Z0-9$_]*/,
+
+		number: ($) => /\d+/,
+
+		_literal: ($) =>
+			choice(
+				$.string_literal,
+				$.number_literal,
+				$.boolean_literal,
+				$.hex_string_literal,
+				$.unicode_string_literal,
+			),
+
+		string_literal: ($) => prec.left(repeat1($.string)),
+		number_literal: ($) =>
+			seq(choice($._decimal_number, $._hex_number), optional($.number_unit)),
+		_decimal_number: ($) =>
+			choice(
+				/(\d|_)+(\.(\d|_)+)?([eE](-)?(\d|_)+)?/,
+				/\.(\d|_)+([eE](-)?(\d|_)+)?/,
+			),
+		_hex_number: ($) => prec(10, /0[xX]([a-fA-F0-9][a-fA-F0-9]?_?)+/),
+		// _hex_number: $ => seq(/0[xX]/, optional(optionalDashSeparation($._hex_digit))),
+		_hex_digit: ($) => /([a-fA-F0-9][a-fA-F0-9])/,
+		number_unit: ($) =>
+			choice(
+				"wei",
+				"szabo",
+				"finney",
+				"gwei",
+				"ether",
+				"seconds",
+				"minutes",
+				"hours",
+				"days",
+				"weeks",
+				"years",
+			),
+		true: ($) => "true",
+		false: ($) => "false",
+		boolean_literal: ($) => choice($.true, $.false),
+
+		hex_string_literal: ($) =>
+			prec.left(
+				repeat1(
+					seq(
+						"hex",
+						choice(
+							seq('"', optional(optionalDashSeparation($._hex_digit)), '"'),
+							seq("'", optional(optionalDashSeparation($._hex_digit)), "'"),
+						),
+					),
+				),
+			),
+
+		_escape_sequence: ($) =>
+			token.immediate(
+				seq(
+					"\\",
+					choice(
+						/[^xu0-7]/,
+						/[0-7]{1,3}/,
+						/x[0-9a-fA-F]{2}/,
+						/u[0-9a-fA-F]{4}/,
+						/u\{[0-9a-fA-F]+\}/,
+					),
+				),
+			),
+		_single_quoted_unicode_char: ($) =>
+			token.immediate(prec(PREC.STRING, /[^'\\\n]+|\\\r?\n/)),
+		_double_quoted_unicode_char: ($) =>
+			token.immediate(prec(PREC.STRING, /[^"\\\n]+|\\\r?\n/)),
+		unicode_string_literal: ($) =>
+			prec.left(
+				repeat1(
+					seq(
+						"unicode",
+						choice(
+							seq('"', repeat($._double_quoted_unicode_char), '"'),
+							seq("'", repeat($._single_quoted_unicode_char), "'"),
+						),
+					),
+				),
+			),
+
+		string: ($) =>
+			choice(
+				seq(
+					'"',
+					repeat(
+						choice(
+							$._string_immediate_elt_inside_double_quote,
+							$._escape_sequence,
+						),
+					),
+					'"',
+				),
+				seq(
+					"'",
+					repeat(
+						choice($._string_immediate_elt_inside_quote, $._escape_sequence),
+					),
+					"'",
+				),
+			),
+		// We need to name those elts for ocaml-tree-sitter-semgrep.
+		_string_immediate_elt_inside_double_quote: ($) =>
+			token.immediate(prec(PREC.STRING, /[^"\\\n]+|\\\r?\n/)),
+		_string_immediate_elt_inside_quote: ($) =>
+			token.immediate(prec(PREC.STRING, /[^'\\\n]+|\\\r?\n/)),
+
+		// Based on: https://github.com/tree-sitter/tree-sitter-c/blob/master/grammar.js#L965
+		comment: ($) =>
+			token(
+				prec(
+					PREC.COMMENT,
+					choice(
+						seq("//", /([^\r\n])*/),
+						seq("/*", /[^*]*\*+([^/*][^*]*\*+)*/, "/"),
+					),
+				),
+			),
+	},
+});
+
+function dotSep1(rule) {
+	return seq(rule, repeat(seq(".", rule)));
+}
+
+function dotSep(rule) {
+	return optional(dotSep1(rule));
+}
+
+function commaSep1(rule) {
+	return seq(rule, repeat(seq(",", rule)), optional(","));
+}
+
+function commaSep(rule) {
+	return optional(commaSep1(rule));
+}
+
+function optionalDashSeparation(rule) {
+	return seq(rule, repeat(seq(optional("_"), rule)));
+}

--- a/langs/group-pine/solidity/def/queries/highlights.scm
+++ b/langs/group-pine/solidity/def/queries/highlights.scm
@@ -1,0 +1,240 @@
+; identifiers
+; -----------
+(identifier) @variable
+((identifier) @variable.builtin (#any-of? @variable.builtin "this" "msg" "block" "tx"))
+(yul_identifier) @variable
+
+; Pragma
+(pragma_directive) @keyword.directive
+(solidity_version_comparison_operator _ @keyword.directive)
+
+; Literals
+; --------
+[
+ (string)
+ (hex_string_literal)
+ (unicode_string_literal)
+ (yul_string_literal)
+] @string
+(hex_string_literal "hex" @string.special.symbol)
+(unicode_string_literal "unicode" @string.special.symbol)
+[
+ (number_literal)
+ (yul_decimal_number)
+ (yul_hex_number)
+] @constant.numeric
+[
+ (true)
+ (false)
+ (yul_boolean)
+] @constant.builtin.boolean
+
+(comment) @comment
+
+; Definitions and references
+; -----------
+(type_name) @type
+
+[
+  (primitive_type)
+  (number_unit)
+] @type.builtin
+
+(user_defined_type (_) @type)
+(user_defined_type_definition name: (identifier) @type)
+(type_alias (identifier) @type)
+
+; Color payable in payable address conversion as type and not as keyword
+(payable_conversion_expression "payable" @type)
+; Ensures that delimiters in mapping( ... => .. ) are not colored like types
+(type_name "(" @punctuation.bracket "=>" @punctuation.delimiter ")" @punctuation.bracket)
+
+; Definitions
+(struct_declaration name: (identifier) @type)
+(enum_declaration name: (identifier) @type)
+(contract_declaration name: (identifier) @type)
+(library_declaration name: (identifier) @type)
+(interface_declaration name: (identifier) @type)
+(event_definition name: (identifier) @type)
+(error_declaration name: (identifier) @type)
+(function_definition name: (identifier) @function)
+(modifier_definition name: (identifier) @function)
+(yul_evm_builtin) @function.builtin
+
+; Use constructor coloring for special functions
+(constructor_definition "constructor" @constructor)
+(error_declaration "error" @constructor)
+(fallback_receive_definition "receive" @constructor)
+(fallback_receive_definition "fallback" @constructor)
+
+(struct_member name: (identifier) @variable.other.member)
+(enum_value) @constant
+; SCREAMING_SNAKE_CASE identifier are constants
+((identifier) @constant (#match? @constant "^[A-Z][A-Z_]+$"))
+
+; Invocations
+(emit_statement name: (expression (identifier) @type))
+(revert_statement error: (expression (identifier) @type))
+(modifier_invocation . (_) @function)
+
+(call_expression . (_(member_expression property: (_) @function.method)))
+(call_expression . (expression (identifier) @function))
+
+; Function parameters
+(call_struct_argument name: (identifier) @field)
+(event_parameter name: (identifier) @variable.parameter)
+(parameter name: (identifier) @variable.parameter)
+
+; Yul functions
+(yul_function_call function: (_) @function)
+(yul_function_definition
+  ("function" (yul_identifier) @function "(" (
+      (yul_identifier) @variable.parameter ("," (yul_identifier) @variable.parameter)*
+    )
+  )
+)
+
+; Structs and members
+(member_expression property: (identifier) @variable.other.member)
+(struct_expression type: ((expression (identifier)) @type .))
+(struct_field_assignment name: (identifier) @variable.other.member)
+
+
+; Tokens
+; -------
+
+; Keywords
+(meta_type_expression "type" @keyword)
+[
+ "abstract"
+ "layout"
+ "contract"
+ "interface"
+ "library"
+ "is"
+ "struct"
+ "enum"
+ "event"
+ "type"
+ "assembly"
+ "emit"
+ "public"
+ "internal"
+ "private"
+ "external"
+ "pure"
+ "view"
+ "payable"
+ "modifier"
+ "var"
+ "let"
+ (virtual)
+ (override_specifier)
+ (yul_leave)
+] @keyword
+
+[
+ "memory"
+ "storage"
+ "calldata"
+ "constant"
+ "transient"
+ (immutable)
+] @keyword.storage.modifier
+
+[
+ "for"
+ "while"
+ "do"
+] @keyword.control.repeat
+
+[
+ "break"
+ "continue"
+ "if"
+ "else"
+ "switch"
+ "case"
+ "default"
+] @keyword.control.conditional
+
+[
+ "try"
+ "catch"
+ "revert"
+] @keyword.control.exception
+
+[
+ "return"
+ "returns"
+] @keyword.control.return
+
+"function" @keyword.function
+
+"import" @keyword.control.import
+"using" @keyword.control.import
+(import_directive "as" @keyword.control.import)
+(import_directive "from" @keyword.control.import)
+(event_parameter "indexed" @keyword)
+
+; Punctuation
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+] @punctuation.bracket
+
+[
+  "."
+  ","
+  ":"
+  "->"
+  "=>"
+] @punctuation.delimiter
+
+; Operators
+[
+  "&&"
+  "||"
+  ">>"
+  "<<"
+  "&"
+  "^"
+  "|"
+  "+"
+  "-"
+  "*"
+  "/"
+  "%"
+  "**"
+  "<"
+  "<="
+  "=="
+  "!="
+  ">="
+  ">"
+  "!"
+  "~"
+  "-"
+  "+"
+  "++"
+  "--"
+  "+="
+  "-="
+  "*="
+  "/="
+  "%="
+  "^="
+  "&="
+  "|="
+  "<<="
+  ">>="
+] @operator
+
+[
+  "delete"
+  "new"
+] @keyword.operator

--- a/langs/group-pine/solidity/def/queries/locals.scm
+++ b/langs/group-pine/solidity/def/queries/locals.scm
@@ -1,0 +1,9 @@
+(function_definition) @local.scope
+(constructor_definition) @local.scope
+(block_statement) @local.scope
+
+(function_definition (parameter name: (identifier) @local.definition.variable.parameter))
+(constructor_definition (parameter name: (identifier) @local.definition.variable.parameter))
+(assignment_expression left: (_) @local.definition)
+
+(identifier) @local.reference

--- a/langs/group-pine/solidity/def/queries/tags.scm
+++ b/langs/group-pine/solidity/def/queries/tags.scm
@@ -1,0 +1,43 @@
+;; Method and Function declarations
+(contract_declaration (_
+    (function_definition
+        name: (identifier) @name) @definition.method))
+
+(source_file
+    (function_definition
+        name: (identifier) @name) @definition.function)
+
+;; Contract, struct, enum and interface declarations
+(contract_declaration
+  name: (identifier) @name) @definition.class
+
+(interface_declaration
+  name: (identifier) @name) @definition.interface
+
+(library_declaration
+  name: (identifier) @name) @definition.interface
+
+(struct_declaration name: (identifier) @name) @definition.class
+(enum_declaration name: (identifier) @name) @definition.class
+(event_definition name: (identifier) @name) @definition.class
+
+;; Function calls
+(call_expression (expression (identifier)) @name ) @reference.call
+
+(call_expression
+    (expression (member_expression
+        property: (_) @name ))) @reference.call
+
+;; Log emit
+(emit_statement name: (_) @name) @reference.class
+
+
+;; Inheritance
+
+(inheritance_specifier
+    ancestor: (user_defined_type (_) @name . )) @reference.class
+
+
+;; Imports ( note that unknown is not standardised )
+(import_directive
+  import_name: (_) @name ) @reference.unknown

--- a/langs/group-pine/solidity/def/samples/example.sol
+++ b/langs/group-pine/solidity/def/samples/example.sol
@@ -1,0 +1,811 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts (last updated v5.5.0) (governance/Governor.sol)
+
+pragma solidity ^0.8.24;
+
+import {IERC721Receiver} from "../token/ERC721/IERC721Receiver.sol";
+import {IERC1155Receiver} from "../token/ERC1155/IERC1155Receiver.sol";
+import {EIP712} from "../utils/cryptography/EIP712.sol";
+import {SignatureChecker} from "../utils/cryptography/SignatureChecker.sol";
+import {IERC165, ERC165} from "../utils/introspection/ERC165.sol";
+import {SafeCast} from "../utils/math/SafeCast.sol";
+import {DoubleEndedQueue} from "../utils/structs/DoubleEndedQueue.sol";
+import {Address} from "../utils/Address.sol";
+import {Context} from "../utils/Context.sol";
+import {Nonces} from "../utils/Nonces.sol";
+import {Strings} from "../utils/Strings.sol";
+import {IGovernor, IERC6372} from "./IGovernor.sol";
+
+/**
+ * @dev Core of the governance system, designed to be extended through various modules.
+ *
+ * This contract is abstract and requires several functions to be implemented in various modules:
+ *
+ * - A counting module must implement {_quorumReached}, {_voteSucceeded} and {_countVote}
+ * - A voting module must implement {_getVotes}
+ * - Additionally, {votingPeriod}, {votingDelay}, and {quorum} must also be implemented
+ */
+abstract contract Governor is Context, ERC165, EIP712, Nonces, IGovernor, IERC721Receiver, IERC1155Receiver {
+    using DoubleEndedQueue for DoubleEndedQueue.Bytes32Deque;
+
+    bytes32 public constant BALLOT_TYPEHASH =
+        keccak256("Ballot(uint256 proposalId,uint8 support,address voter,uint256 nonce)");
+    bytes32 public constant EXTENDED_BALLOT_TYPEHASH = keccak256(
+        "ExtendedBallot(uint256 proposalId,uint8 support,address voter,uint256 nonce,string reason,bytes params)"
+    );
+
+    struct ProposalCore {
+        address proposer;
+        uint48 voteStart;
+        uint32 voteDuration;
+        bool executed;
+        bool canceled;
+        uint48 etaSeconds;
+    }
+
+    bytes32 private constant ALL_PROPOSAL_STATES_BITMAP = bytes32((2 ** (uint8(type(ProposalState).max) + 1)) - 1);
+    string private _name;
+
+    mapping(uint256 proposalId => ProposalCore) private _proposals;
+
+    // This queue keeps track of the governor operating on itself. Calls to functions protected by the {onlyGovernance}
+    // modifier needs to be whitelisted in this queue. Whitelisting is set in {execute}, consumed by the
+    // {onlyGovernance} modifier and eventually reset after {_executeOperations} completes. This ensures that the
+    // execution of {onlyGovernance} protected calls can only be achieved through successful proposals.
+    DoubleEndedQueue.Bytes32Deque private _governanceCall;
+
+    /**
+     * @dev Restricts a function so it can only be executed through governance proposals. For example, governance
+     * parameter setters in {GovernorSettings} are protected using this modifier.
+     *
+     * The governance executing address may be different from the Governor's own address, for example it could be a
+     * timelock. This can be customized by modules by overriding {_executor}. The executor is only able to invoke these
+     * functions during the execution of the governor's {execute} function, and not under any other circumstances. Thus,
+     * for example, additional timelock proposers are not able to change governance parameters without going through the
+     * governance protocol (since v4.6).
+     */
+    modifier onlyGovernance() {
+        _checkGovernance();
+        _;
+    }
+
+    /**
+     * @dev Sets the value for {name} and {version}
+     */
+    constructor(string memory name_) EIP712(name_, version()) {
+        _name = name_;
+    }
+
+    /**
+     * @dev Function to receive ETH that will be handled by the governor (disabled if executor is a third party contract)
+     */
+    receive() external payable virtual {
+        if (_executor() != address(this)) {
+            revert GovernorDisabledDeposit();
+        }
+    }
+
+    /// @inheritdoc IERC165
+    function supportsInterface(bytes4 interfaceId) public view virtual override(IERC165, ERC165) returns (bool) {
+        return interfaceId == type(IGovernor).interfaceId
+            || interfaceId == type(IGovernor).interfaceId ^ IGovernor.getProposalId.selector
+            || interfaceId == type(IERC1155Receiver).interfaceId || super.supportsInterface(interfaceId);
+    }
+
+    /// @inheritdoc IGovernor
+    function name() public view virtual returns (string memory) {
+        return _name;
+    }
+
+    /// @inheritdoc IGovernor
+    function version() public view virtual returns (string memory) {
+        return "1";
+    }
+
+    /**
+     * @dev See {IGovernor-hashProposal}.
+     *
+     * The proposal id is produced by hashing the ABI encoded `targets` array, the `values` array, the `calldatas` array
+     * and the descriptionHash (bytes32 which itself is the keccak256 hash of the description string). This proposal id
+     * can be produced from the proposal data which is part of the {ProposalCreated} event. It can even be computed in
+     * advance, before the proposal is submitted.
+     *
+     * Note that the chainId and the governor address are not part of the proposal id computation. Consequently, the
+     * same proposal (with same operation and same description) will have the same id if submitted on multiple governors
+     * across multiple networks. This also means that in order to execute the same operation twice (on the same
+     * governor) the proposer will have to change the description in order to avoid proposal id conflicts.
+     */
+    function hashProposal(
+        address[] memory targets,
+        uint256[] memory values,
+        bytes[] memory calldatas,
+        bytes32 descriptionHash
+    ) public pure virtual returns (uint256) {
+        return uint256(keccak256(abi.encode(targets, values, calldatas, descriptionHash)));
+    }
+
+    /// @inheritdoc IGovernor
+    function getProposalId(
+        address[] memory targets,
+        uint256[] memory values,
+        bytes[] memory calldatas,
+        bytes32 descriptionHash
+    ) public view virtual returns (uint256) {
+        return hashProposal(targets, values, calldatas, descriptionHash);
+    }
+
+    /// @inheritdoc IGovernor
+    function state(uint256 proposalId) public view virtual returns (ProposalState) {
+        // We read the struct fields into the stack at once so Solidity emits a single SLOAD
+        ProposalCore storage proposal = _proposals[proposalId];
+        bool proposalExecuted = proposal.executed;
+        bool proposalCanceled = proposal.canceled;
+
+        if (proposalExecuted) {
+            return ProposalState.Executed;
+        }
+
+        if (proposalCanceled) {
+            return ProposalState.Canceled;
+        }
+
+        uint256 snapshot = proposalSnapshot(proposalId);
+
+        if (snapshot == 0) {
+            revert GovernorNonexistentProposal(proposalId);
+        }
+
+        uint256 currentTimepoint = clock();
+
+        if (snapshot >= currentTimepoint) {
+            return ProposalState.Pending;
+        }
+
+        uint256 deadline = proposalDeadline(proposalId);
+
+        if (deadline >= currentTimepoint) {
+            return ProposalState.Active;
+        } else if (!_quorumReached(proposalId) || !_voteSucceeded(proposalId)) {
+            return ProposalState.Defeated;
+        } else if (proposalEta(proposalId) == 0) {
+            return ProposalState.Succeeded;
+        } else {
+            return ProposalState.Queued;
+        }
+    }
+
+    /// @inheritdoc IGovernor
+    function proposalThreshold() public view virtual returns (uint256) {
+        return 0;
+    }
+
+    /// @inheritdoc IGovernor
+    function proposalSnapshot(uint256 proposalId) public view virtual returns (uint256) {
+        return _proposals[proposalId].voteStart;
+    }
+
+    /// @inheritdoc IGovernor
+    function proposalDeadline(uint256 proposalId) public view virtual returns (uint256) {
+        return _proposals[proposalId].voteStart + _proposals[proposalId].voteDuration;
+    }
+
+    /// @inheritdoc IGovernor
+    function proposalProposer(uint256 proposalId) public view virtual returns (address) {
+        return _proposals[proposalId].proposer;
+    }
+
+    /// @inheritdoc IGovernor
+    function proposalEta(uint256 proposalId) public view virtual returns (uint256) {
+        return _proposals[proposalId].etaSeconds;
+    }
+
+    /// @inheritdoc IGovernor
+    function proposalNeedsQueuing(uint256) public view virtual returns (bool) {
+        return false;
+    }
+
+    /**
+     * @dev Reverts if the `msg.sender` is not the executor. In case the executor is not this contract
+     * itself, the function reverts if `msg.data` is not whitelisted as a result of an {execute}
+     * operation. See {onlyGovernance}.
+     */
+    function _checkGovernance() internal virtual {
+        if (_executor() != _msgSender()) {
+            revert GovernorOnlyExecutor(_msgSender());
+        }
+        if (_executor() != address(this)) {
+            bytes32 msgDataHash = keccak256(_msgData());
+            // loop until popping the expected operation - throw if deque is empty (operation not authorized)
+            while (_governanceCall.popFront() != msgDataHash) {}
+        }
+    }
+
+    /**
+     * @dev Amount of votes already cast passes the threshold limit.
+     */
+    function _quorumReached(uint256 proposalId) internal view virtual returns (bool);
+
+    /**
+     * @dev Is the proposal successful or not.
+     */
+    function _voteSucceeded(uint256 proposalId) internal view virtual returns (bool);
+
+    /**
+     * @dev Get the voting weight of `account` at a specific `timepoint`, for a vote as described by `params`.
+     */
+    function _getVotes(address account, uint256 timepoint, bytes memory params) internal view virtual returns (uint256);
+
+    /**
+     * @dev Register a vote for `proposalId` by `account` with a given `support`, voting `weight` and voting `params`.
+     *
+     * Note: Support is generic and can represent various things depending on the voting system used.
+     */
+    function _countVote(uint256 proposalId, address account, uint8 support, uint256 totalWeight, bytes memory params)
+        internal
+        virtual
+        returns (uint256);
+
+    /**
+     * @dev Hook that should be called every time the tally for a proposal is updated.
+     *
+     * Note: This function must run successfully. Reverts will result in the bricking of governance
+     */
+    function _tallyUpdated(uint256 proposalId) internal virtual {}
+
+    /**
+     * @dev Default additional encoded parameters used by castVote methods that don't include them
+     *
+     * Note: Should be overridden by specific implementations to use an appropriate value, the
+     * meaning of the additional params, in the context of that implementation
+     */
+    function _defaultParams() internal view virtual returns (bytes memory) {
+        return "";
+    }
+
+    /**
+     * @dev See {IGovernor-propose}. This function has opt-in frontrunning protection, described in {_isValidDescriptionForProposer}.
+     */
+    function propose(
+        address[] memory targets,
+        uint256[] memory values,
+        bytes[] memory calldatas,
+        string memory description
+    ) public virtual returns (uint256) {
+        address proposer = _msgSender();
+
+        // check description restriction
+        if (!_isValidDescriptionForProposer(proposer, description)) {
+            revert GovernorRestrictedProposer(proposer);
+        }
+
+        // check proposal threshold
+        uint256 votesThreshold = proposalThreshold();
+        if (votesThreshold > 0) {
+            uint256 proposerVotes = getVotes(proposer, clock() - 1);
+            if (proposerVotes < votesThreshold) {
+                revert GovernorInsufficientProposerVotes(proposer, proposerVotes, votesThreshold);
+            }
+        }
+
+        return _propose(targets, values, calldatas, description, proposer);
+    }
+
+    /**
+     * @dev Internal propose mechanism. Can be overridden to add more logic on proposal creation.
+     *
+     * Emits a {IGovernor-ProposalCreated} event.
+     */
+    function _propose(
+        address[] memory targets,
+        uint256[] memory values,
+        bytes[] memory calldatas,
+        string memory description,
+        address proposer
+    ) internal virtual returns (uint256 proposalId) {
+        proposalId = getProposalId(targets, values, calldatas, keccak256(bytes(description)));
+
+        if (targets.length != values.length || targets.length != calldatas.length || targets.length == 0) {
+            revert GovernorInvalidProposalLength(targets.length, calldatas.length, values.length);
+        }
+        if (_proposals[proposalId].voteStart != 0) {
+            revert GovernorUnexpectedProposalState(proposalId, state(proposalId), bytes32(0));
+        }
+
+        uint256 snapshot = clock() + votingDelay();
+        uint256 duration = votingPeriod();
+
+        ProposalCore storage proposal = _proposals[proposalId];
+        proposal.proposer = proposer;
+        proposal.voteStart = SafeCast.toUint48(snapshot);
+        proposal.voteDuration = SafeCast.toUint32(duration);
+
+        emit ProposalCreated(
+            proposalId,
+            proposer,
+            targets,
+            values,
+            new string[](targets.length),
+            calldatas,
+            snapshot,
+            snapshot + duration,
+            description
+        );
+
+        // Using a named return variable to avoid stack too deep errors
+    }
+
+    /// @inheritdoc IGovernor
+    function queue(address[] memory targets, uint256[] memory values, bytes[] memory calldatas, bytes32 descriptionHash)
+        public
+        virtual
+        returns (uint256)
+    {
+        uint256 proposalId = getProposalId(targets, values, calldatas, descriptionHash);
+
+        _validateStateBitmap(proposalId, _encodeStateBitmap(ProposalState.Succeeded));
+
+        uint48 etaSeconds = _queueOperations(proposalId, targets, values, calldatas, descriptionHash);
+
+        if (etaSeconds != 0) {
+            _proposals[proposalId].etaSeconds = etaSeconds;
+            emit ProposalQueued(proposalId, etaSeconds);
+        } else {
+            revert GovernorQueueNotImplemented();
+        }
+
+        return proposalId;
+    }
+
+    /**
+     * @dev Internal queuing mechanism. Can be overridden (without a super call) to modify the way queuing is
+     * performed (for example adding a vault/timelock).
+     *
+     * This is empty by default, and must be overridden to implement queuing.
+     *
+     * This function returns a timestamp that describes the expected ETA for execution. If the returned value is 0
+     * (which is the default value), the core will consider queueing did not succeed, and the public {queue} function
+     * will revert.
+     *
+     * NOTE: Calling this function directly will NOT check the current state of the proposal, or emit the
+     * `ProposalQueued` event. Queuing a proposal should be done using {queue}.
+     */
+    function _queueOperations(
+        uint256,
+        /*proposalId*/
+        address[] memory,
+        /*targets*/
+        uint256[] memory,
+        /*values*/
+        bytes[] memory,
+        /*calldatas*/
+        bytes32 /*descriptionHash*/
+    )
+        internal
+        virtual
+        returns (uint48)
+    {
+        return 0;
+    }
+
+    /// @inheritdoc IGovernor
+    function execute(
+        address[] memory targets,
+        uint256[] memory values,
+        bytes[] memory calldatas,
+        bytes32 descriptionHash
+    ) public payable virtual returns (uint256) {
+        uint256 proposalId = getProposalId(targets, values, calldatas, descriptionHash);
+
+        _validateStateBitmap(
+            proposalId, _encodeStateBitmap(ProposalState.Succeeded) | _encodeStateBitmap(ProposalState.Queued)
+        );
+
+        // mark as executed before calls to avoid reentrancy
+        _proposals[proposalId].executed = true;
+
+        // before execute: register governance call in queue.
+        if (_executor() != address(this)) {
+            for (uint256 i = 0; i < targets.length; ++i) {
+                if (targets[i] == address(this)) {
+                    _governanceCall.pushBack(keccak256(calldatas[i]));
+                }
+            }
+        }
+
+        _executeOperations(proposalId, targets, values, calldatas, descriptionHash);
+
+        // after execute: cleanup governance call queue.
+        if (_executor() != address(this) && !_governanceCall.empty()) {
+            _governanceCall.clear();
+        }
+
+        emit ProposalExecuted(proposalId);
+
+        return proposalId;
+    }
+
+    /**
+     * @dev Internal execution mechanism. Can be overridden (without a super call) to modify the way execution is
+     * performed (for example adding a vault/timelock).
+     *
+     * NOTE: Calling this function directly will NOT check the current state of the proposal, set the executed flag to
+     * true or emit the `ProposalExecuted` event. Executing a proposal should be done using {execute}.
+     */
+    function _executeOperations(
+        uint256,
+        /* proposalId */
+        address[] memory targets,
+        uint256[] memory values,
+        bytes[] memory calldatas,
+        bytes32 /*descriptionHash*/
+    ) internal virtual {
+        for (uint256 i = 0; i < targets.length; ++i) {
+            (bool success, bytes memory returndata) = targets[i].call{value: values[i]}(calldatas[i]);
+            Address.verifyCallResult(success, returndata);
+        }
+    }
+
+    /// @inheritdoc IGovernor
+    function cancel(
+        address[] memory targets,
+        uint256[] memory values,
+        bytes[] memory calldatas,
+        bytes32 descriptionHash
+    ) public virtual returns (uint256) {
+        // The proposalId will be recomputed in the `_cancel` call further down. However we need the value before we
+        // do the internal call, because we need to check the proposal state BEFORE the internal `_cancel` call
+        // changes it. The `getProposalId` duplication has a cost that is limited, and that we accept.
+        uint256 proposalId = getProposalId(targets, values, calldatas, descriptionHash);
+
+        address caller = _msgSender();
+        if (!_validateCancel(proposalId, caller)) revert GovernorUnableToCancel(proposalId, caller);
+
+        return _cancel(targets, values, calldatas, descriptionHash);
+    }
+
+    /**
+     * @dev Internal cancel mechanism with minimal restrictions. A proposal can be cancelled in any state other than
+     * Canceled, Expired, or Executed. Once cancelled a proposal can't be re-submitted.
+     *
+     * Emits a {IGovernor-ProposalCanceled} event.
+     */
+    function _cancel(
+        address[] memory targets,
+        uint256[] memory values,
+        bytes[] memory calldatas,
+        bytes32 descriptionHash
+    ) internal virtual returns (uint256) {
+        uint256 proposalId = getProposalId(targets, values, calldatas, descriptionHash);
+
+        _validateStateBitmap(
+            proposalId,
+            ALL_PROPOSAL_STATES_BITMAP ^ _encodeStateBitmap(ProposalState.Canceled)
+                ^ _encodeStateBitmap(ProposalState.Expired) ^ _encodeStateBitmap(ProposalState.Executed)
+        );
+
+        _proposals[proposalId].canceled = true;
+        emit ProposalCanceled(proposalId);
+
+        return proposalId;
+    }
+
+    /// @inheritdoc IGovernor
+    function getVotes(address account, uint256 timepoint) public view virtual returns (uint256) {
+        return _getVotes(account, timepoint, _defaultParams());
+    }
+
+    /// @inheritdoc IGovernor
+    function getVotesWithParams(address account, uint256 timepoint, bytes memory params)
+        public
+        view
+        virtual
+        returns (uint256)
+    {
+        return _getVotes(account, timepoint, params);
+    }
+
+    /// @inheritdoc IGovernor
+    function castVote(uint256 proposalId, uint8 support) public virtual returns (uint256) {
+        address voter = _msgSender();
+        return _castVote(proposalId, voter, support, "");
+    }
+
+    /// @inheritdoc IGovernor
+    function castVoteWithReason(uint256 proposalId, uint8 support, string calldata reason)
+        public
+        virtual
+        returns (uint256)
+    {
+        address voter = _msgSender();
+        return _castVote(proposalId, voter, support, reason);
+    }
+
+    /// @inheritdoc IGovernor
+    function castVoteWithReasonAndParams(uint256 proposalId, uint8 support, string calldata reason, bytes memory params)
+        public
+        virtual
+        returns (uint256)
+    {
+        address voter = _msgSender();
+        return _castVote(proposalId, voter, support, reason, params);
+    }
+
+    /// @inheritdoc IGovernor
+    function castVoteBySig(uint256 proposalId, uint8 support, address voter, bytes memory signature)
+        public
+        virtual
+        returns (uint256)
+    {
+        if (!_validateVoteSig(proposalId, support, voter, signature)) {
+            revert GovernorInvalidSignature(voter);
+        }
+        return _castVote(proposalId, voter, support, "");
+    }
+
+    /// @inheritdoc IGovernor
+    function castVoteWithReasonAndParamsBySig(
+        uint256 proposalId,
+        uint8 support,
+        address voter,
+        string calldata reason,
+        bytes memory params,
+        bytes memory signature
+    ) public virtual returns (uint256) {
+        if (!_validateExtendedVoteSig(proposalId, support, voter, reason, params, signature)) {
+            revert GovernorInvalidSignature(voter);
+        }
+        return _castVote(proposalId, voter, support, reason, params);
+    }
+
+    /// @dev Validate the `signature` used in {castVoteBySig} function.
+    function _validateVoteSig(uint256 proposalId, uint8 support, address voter, bytes memory signature)
+        internal
+        virtual
+        returns (bool)
+    {
+        return SignatureChecker.isValidSignatureNow(
+            voter,
+            _hashTypedDataV4(keccak256(abi.encode(BALLOT_TYPEHASH, proposalId, support, voter, _useNonce(voter)))),
+            signature
+        );
+    }
+
+    /// @dev Validate the `signature` used in {castVoteWithReasonAndParamsBySig} function.
+    function _validateExtendedVoteSig(
+        uint256 proposalId,
+        uint8 support,
+        address voter,
+        string memory reason,
+        bytes memory params,
+        bytes memory signature
+    ) internal virtual returns (bool) {
+        return SignatureChecker.isValidSignatureNow(
+            voter,
+            _hashTypedDataV4(
+                keccak256(
+                    abi.encode(
+                        EXTENDED_BALLOT_TYPEHASH,
+                        proposalId,
+                        support,
+                        voter,
+                        _useNonce(voter),
+                        keccak256(bytes(reason)),
+                        keccak256(params)
+                    )
+                )
+            ),
+            signature
+        );
+    }
+
+    /**
+     * @dev Internal vote casting mechanism: Check that the vote is pending, that it has not been cast yet, retrieve
+     * voting weight using {IGovernor-getVotes} and call the {_countVote} internal function. Uses the _defaultParams().
+     *
+     * Emits a {IGovernor-VoteCast} event.
+     */
+    function _castVote(uint256 proposalId, address account, uint8 support, string memory reason)
+        internal
+        virtual
+        returns (uint256)
+    {
+        return _castVote(proposalId, account, support, reason, _defaultParams());
+    }
+
+    /**
+     * @dev Internal vote casting mechanism: Check that the vote is pending, that it has not been cast yet, retrieve
+     * voting weight using {IGovernor-getVotes} and call the {_countVote} internal function.
+     *
+     * Emits a {IGovernor-VoteCast} event.
+     */
+    function _castVote(uint256 proposalId, address account, uint8 support, string memory reason, bytes memory params)
+        internal
+        virtual
+        returns (uint256)
+    {
+        _validateStateBitmap(proposalId, _encodeStateBitmap(ProposalState.Active));
+
+        uint256 totalWeight = _getVotes(account, proposalSnapshot(proposalId), params);
+        uint256 votedWeight = _countVote(proposalId, account, support, totalWeight, params);
+
+        if (params.length == 0) {
+            emit VoteCast(account, proposalId, support, votedWeight, reason);
+        } else {
+            emit VoteCastWithParams(account, proposalId, support, votedWeight, reason, params);
+        }
+
+        _tallyUpdated(proposalId);
+
+        return votedWeight;
+    }
+
+    /**
+     * @dev Relays a transaction or function call to an arbitrary target. In cases where the governance executor
+     * is some contract other than the governor itself, like when using a timelock, this function can be invoked
+     * in a governance proposal to recover tokens or Ether that was sent to the governor contract by mistake.
+     * Note that if the executor is simply the governor itself, use of `relay` is redundant.
+     */
+    function relay(address target, uint256 value, bytes calldata data) public payable virtual onlyGovernance {
+        (bool success, bytes memory returndata) = target.call{value: value}(data);
+        Address.verifyCallResult(success, returndata);
+    }
+
+    /**
+     * @dev Address through which the governor executes action. Will be overloaded by module that executes actions
+     * through another contract such as a timelock.
+     */
+    function _executor() internal view virtual returns (address) {
+        return address(this);
+    }
+
+    /**
+     * @dev See {IERC721Receiver-onERC721Received}.
+     * Receiving tokens is disabled if the governance executor is other than the governor itself (eg. when using with a timelock).
+     */
+    function onERC721Received(address, address, uint256, bytes memory) public virtual returns (bytes4) {
+        if (_executor() != address(this)) {
+            revert GovernorDisabledDeposit();
+        }
+        return this.onERC721Received.selector;
+    }
+
+    /**
+     * @dev See {IERC1155Receiver-onERC1155Received}.
+     * Receiving tokens is disabled if the governance executor is other than the governor itself (eg. when using with a timelock).
+     */
+    function onERC1155Received(address, address, uint256, uint256, bytes memory) public virtual returns (bytes4) {
+        if (_executor() != address(this)) {
+            revert GovernorDisabledDeposit();
+        }
+        return this.onERC1155Received.selector;
+    }
+
+    /**
+     * @dev See {IERC1155Receiver-onERC1155BatchReceived}.
+     * Receiving tokens is disabled if the governance executor is other than the governor itself (eg. when using with a timelock).
+     */
+    function onERC1155BatchReceived(address, address, uint256[] memory, uint256[] memory, bytes memory)
+        public
+        virtual
+        returns (bytes4)
+    {
+        if (_executor() != address(this)) {
+            revert GovernorDisabledDeposit();
+        }
+        return this.onERC1155BatchReceived.selector;
+    }
+
+    /**
+     * @dev Encodes a `ProposalState` into a `bytes32` representation where each bit enabled corresponds to
+     * the underlying position in the `ProposalState` enum. For example:
+     *
+     * 0x000...10000
+     *   ^^^^^^------ ...
+     *         ^----- Succeeded
+     *          ^---- Defeated
+     *           ^--- Canceled
+     *            ^-- Active
+     *             ^- Pending
+     */
+    function _encodeStateBitmap(ProposalState proposalState) internal pure returns (bytes32) {
+        return bytes32(1 << uint8(proposalState));
+    }
+
+    /**
+     * @dev Check that the current state of a proposal matches the requirements described by the `allowedStates` bitmap.
+     * This bitmap should be built using `_encodeStateBitmap`.
+     *
+     * If requirements are not met, reverts with a {GovernorUnexpectedProposalState} error.
+     */
+    function _validateStateBitmap(uint256 proposalId, bytes32 allowedStates) internal view returns (ProposalState) {
+        ProposalState currentState = state(proposalId);
+        if (_encodeStateBitmap(currentState) & allowedStates == bytes32(0)) {
+            revert GovernorUnexpectedProposalState(proposalId, currentState, allowedStates);
+        }
+        return currentState;
+    }
+
+    /**
+     * @dev Check if the proposer is authorized to submit a proposal with the given description.
+     *
+     * If the proposal description ends with `#proposer=0x???`, where `0x???` is an address written as a hex string
+     * (case insensitive), then the submission of this proposal will only be authorized to said address.
+     *
+     * This is used for frontrunning protection. By adding this pattern at the end of their proposal, one can ensure
+     * that no other address can submit the same proposal. An attacker would have to either remove or change that part,
+     * which would result in a different proposal id.
+     *
+     * If the description does not match this pattern, it is unrestricted and anyone can submit it. This includes:
+     *
+     * - If the `0x???` part is not a valid hex string.
+     * - If the `0x???` part is a valid hex string, but does not contain exactly 40 hex digits.
+     * - If it ends with the expected suffix followed by newlines or other whitespace.
+     * - If it ends with some other similar suffix, e.g. `#other=abc`.
+     * - If it does not end with any such suffix.
+     */
+    function _isValidDescriptionForProposer(address proposer, string memory description)
+        internal
+        view
+        virtual
+        returns (bool)
+    {
+        unchecked {
+            uint256 length = bytes(description).length;
+
+            // Length is too short to contain a valid proposer suffix
+            if (length < 52) {
+                return true;
+            }
+
+            // Extract what would be the `#proposer=` marker beginning the suffix
+            bytes10 marker = bytes10(_unsafeReadBytesOffset(bytes(description), length - 52));
+
+            // If the marker is not found, there is no proposer suffix to check
+            if (marker != bytes10("#proposer=")) {
+                return true;
+            }
+
+            // Check that the last 42 characters (after the marker) are a properly formatted address.
+            (bool success, address recovered) = Strings.tryParseAddress(description, length - 42, length);
+            return !success || recovered == proposer;
+        }
+    }
+
+    /**
+     * @dev Check if the `caller` can cancel the proposal with the given `proposalId`.
+     *
+     * The default implementation allows the proposal proposer to cancel the proposal during the pending state.
+     */
+    function _validateCancel(uint256 proposalId, address caller) internal view virtual returns (bool) {
+        return (state(proposalId) == ProposalState.Pending) && caller == proposalProposer(proposalId);
+    }
+
+    /// @inheritdoc IERC6372
+    function clock() public view virtual returns (uint48);
+
+    /// @inheritdoc IERC6372
+    // solhint-disable-next-line func-name-mixedcase
+    function CLOCK_MODE() public view virtual returns (string memory);
+
+    /// @inheritdoc IGovernor
+    function votingDelay() public view virtual returns (uint256);
+
+    /// @inheritdoc IGovernor
+    function votingPeriod() public view virtual returns (uint256);
+
+    /// @inheritdoc IGovernor
+    function quorum(uint256 timepoint) public view virtual returns (uint256);
+
+    /**
+     * @dev Reads a bytes32 from a bytes array without bounds checking.
+     *
+     * NOTE: making this function internal would mean it could be used with memory unsafe offset, and marking the
+     * assembly block as such would prevent some optimizations.
+     */
+    function _unsafeReadBytesOffset(bytes memory buffer, uint256 offset) private pure returns (bytes32 value) {
+        // This is not memory safe in the general case, but all calls to this private function are within bounds.
+        assembly ("memory-safe") {
+            value := mload(add(add(buffer, 0x20), offset))
+        }
+    }
+}


### PR DESCRIPTION
Ran the generation and build locally, which mostly worked, but the served web app didn't work properly (it said "unsupported language" for all languages). I don't think it's related to what I added here so I'm going ahead.

Note that during compilation I noticed it added the groovy demo sample, so I kept it here since it's seemingly missing.

I took the liberty to add a nix flake because I had trouble to find out what the required dependencies were for local development. Happy to remove it upon request if it's not desired.

Note about the queries: I created improved queries for the `helix` editor upstream so I didn't use the query files coming from the `tree-sitter-solidity` repo, but those ones instead.