### PR TITLE
fix: avoid duplicate CSS properties by tracking emitted highlight tags

### DIFF
--- a/crates/arborium-theme/src/theme.rs
+++ b/crates/arborium-theme/src/theme.rs
@@ -376,9 +376,11 @@ impl Theme {
         }
 
         // Generate rules for each highlight category
+        // Track emitted tags to avoid duplicates (multiple HIGHLIGHTS can share the same tag)
+        let mut emitted_tags: std::collections::HashSet<&str> = std::collections::HashSet::new();
         for (i, def) in HIGHLIGHTS.iter().enumerate() {
-            if def.tag.is_empty() {
-                continue; // Skip categories like "none" that have no tag
+            if def.tag.is_empty() || emitted_tags.contains(def.tag) {
+                continue; // Skip categories like "none" that have no tag, or already emitted tags
             }
 
             // Use own style, or fall back to parent style
@@ -397,6 +399,8 @@ impl Theme {
             if style.is_empty() {
                 continue;
             }
+
+            emitted_tags.insert(def.tag);
 
             write!(css, "  a-{} {{", def.tag).unwrap();
 

--- a/xtask/src/serve.rs
+++ b/xtask/src/serve.rs
@@ -1515,8 +1515,10 @@ pub fn generate_npm_theme_css(crates_dir: &Utf8Path) -> Result<(), String> {
         }
 
         // Generate CSS variables for each highlight category
+        // Track emitted tags to avoid duplicates (multiple HIGHLIGHTS can share the same tag)
+        let mut emitted_tags: std::collections::HashSet<&str> = std::collections::HashSet::new();
         for (i, def) in HIGHLIGHTS.iter().enumerate() {
-            if def.tag.is_empty() {
+            if def.tag.is_empty() || emitted_tags.contains(def.tag) {
                 continue;
             }
 
@@ -1535,6 +1537,8 @@ pub fn generate_npm_theme_css(crates_dir: &Utf8Path) -> Result<(), String> {
             } else {
                 continue;
             };
+
+            emitted_tags.insert(def.tag);
 
             if let Some(fg) = &style.fg {
                 writeln!(css, "  --arb-{}-{}: {};", def.tag, variant, fg.to_hex()).unwrap();

--- a/xtask/src/theme_gen.rs
+++ b/xtask/src/theme_gen.rs
@@ -133,14 +133,17 @@ impl Theme {
         writeln!(css, "}}").unwrap();
 
         // Generate styles for each highlight tag
+        // Track emitted tags to avoid duplicates (multiple HIGHLIGHTS can share the same tag)
+        let mut emitted_tags: std::collections::HashSet<&str> = std::collections::HashSet::new();
         for (i, def) in HIGHLIGHTS.iter().enumerate() {
-            if def.tag.is_empty() {
+            if def.tag.is_empty() || emitted_tags.contains(def.tag) {
                 continue;
             }
             if let Some(style) = self.styles.get(i) {
                 if style.is_empty() {
                     continue;
                 }
+                emitted_tags.insert(def.tag);
                 write!(css, "{selector_prefix} a-{}", def.tag).unwrap();
                 css.push_str(" {\n");
                 if let Some(fg) = &style.fg {


### PR DESCRIPTION
## Summary

Multiple HIGHLIGHTS entries can share the same tag (e.g., different highlight categories aliasing to the same CSS class). Previously, this caused duplicate CSS property definitions in the generated output. This PR adds a HashSet to track already-emitted tags and skip subsequent duplicates.

## Changes

- Added `emitted_tags: HashSet<&str>` tracking in `theme.rs`, `serve.rs`, and `theme_gen.rs`
- Modified the iteration loop to skip tags that have already been written
- Preserves the first style definition for each tag, skipping later duplicates

## Testing

- The fix applies the same pattern consistently across all three CSS generation sites

Fixes #109