### PR TITLE
fix(styx): correct key path highlighting

### DIFF
--- a/langs/group-maple/styx/def/arborium.yaml
+++ b/langs/group-maple/styx/def/arborium.yaml
@@ -1,5 +1,5 @@
 repo: https://github.com/bearcove/styx
-commit: fb9d97e3d0c79c5dc2eb0d4eb4e6da20e0d77a3e
+commit: 5b09e6c815afe4a416ec07e569d3211b9c49e604
 license: MIT OR Apache-2.0
 
 grammars:

--- a/langs/group-maple/styx/def/grammar/grammar.js
+++ b/langs/group-maple/styx/def/grammar/grammar.js
@@ -35,6 +35,8 @@ module.exports = grammar({
     [$.attributes],
     // Object body can be newline or comma separated
     [$._newline_separated, $._comma_separated],
+    // Entry key path: can't tell if next expr is another key or the value
+    [$.entry],
   ],
 
   rules: {
@@ -43,14 +45,19 @@ module.exports = grammar({
     document: ($) =>
       seq(repeat($._newline), repeat(seq(optional($.doc_comment), $.entry, repeat($._newline)))),
 
-    // Entry: key followed by optional value
+    // Entry: key path followed by optional value
     // - key only = implicit unit value
     // - key + value = explicit value
+    // - key key ... value = nested key path (N-1 keys, 1 value)
+    //
+    // Per r[entry.structure] and r[entry.keypath]:
+    // When an entry has N atoms (N > 2), the first N-1 atoms form keys
+    // and only the last atom is the value.
     entry: ($) =>
       prec.right(
         choice(
-          // Key with value(s)
-          seq(field("key", $.expr), field("value", $.expr), repeat(field("value", $.expr))),
+          // Key with value(s) - first N-1 are keys, last is value
+          seq(field("key", $.expr), repeat(field("key", $.expr)), field("value", $.expr)),
           // Key only (implicit unit value)
           field("key", $.expr),
         ),


### PR DESCRIPTION
Update styx grammar to properly mark all keys in a key path as `key:` fields instead of `value:` fields.

For `fee fi foe fum`, fee/fi/foe are now all highlighted as properties (keys) and only fum as a value.

Per r[entry.structure] and r[entry.keypath]: when an entry has N atoms, the first N-1 form keys and only the last is the value.

Upstream commit: https://github.com/bearcove/styx/commit/5b09e6c815afe4a416ec07e569d3211b9c49e604