### PR TITLE
Update styx grammar to include heredoc indentation fix

### DIFF
--- a/langs/group-maple/styx/def/arborium.yaml
+++ b/langs/group-maple/styx/def/arborium.yaml
@@ -1,5 +1,5 @@
 repo: https://github.com/bearcove/styx
-commit: 5b09e6c815afe4a416ec07e569d3211b9c49e604
+commit: 643357e9cd940dbc06e7b96e5f1e67fb2f25e8d4
 license: MIT OR Apache-2.0
 
 grammars:


### PR DESCRIPTION
Updates the styx tree-sitter grammar to commit 643357e which includes support for indented heredoc closing delimiters.

**The fix:**
Previously, heredocs with indented closing delimiters would fail to parse:

```styx
key <<DOC
  this didn't work
  DOC
```

The scanner now properly skips leading whitespace when checking for the closing delimiter.