### PR TITLE
feat: add configurable logger to silence or redirect log output

### DIFF
--- a/packages/arborium/src/iife.ts
+++ b/packages/arborium/src/iife.ts
@@ -167,7 +167,7 @@ function injectBaseCSS(config: Required<ArboriumConfig>): void {
   if (document.getElementById(baseId)) return;
 
   const cssUrl = `${getCssBaseUrl(config)}/base-rustdoc.css`;
-  console.debug(`[arborium] Loading base CSS: ${cssUrl}`);
+  config.logger.debug(`[arborium] Loading base CSS: ${cssUrl}`);
 
   const link = document.createElement("link");
   link.id = baseId;
@@ -185,7 +185,7 @@ function injectThemeCSS(config: Required<ArboriumConfig>): void {
     const oldLink = document.getElementById(`arborium-theme-${currentThemeId}`);
     if (oldLink) {
       oldLink.remove();
-      console.debug(`[arborium] Removed theme: ${currentThemeId}`);
+      config.logger.debug(`[arborium] Removed theme: ${currentThemeId}`);
     }
   }
 
@@ -196,7 +196,7 @@ function injectThemeCSS(config: Required<ArboriumConfig>): void {
   }
 
   const cssUrl = `${getCssBaseUrl(config)}/${theme}.css`;
-  console.debug(`[arborium] Loading theme: ${cssUrl}`);
+  config.logger.debug(`[arborium] Loading theme: ${cssUrl}`);
 
   const link = document.createElement("link");
   link.id = themeId;
@@ -272,7 +272,7 @@ function getLanguageForBlock(block: HTMLElement): string | null {
 async function highlightBlock(
   block: HTMLElement,
   language: string,
-  config: Partial<ArboriumConfig>,
+  config: Required<ArboriumConfig>,
 ): Promise<void> {
   const source = block.textContent || "";
   if (!source.trim()) return;
@@ -283,7 +283,7 @@ async function highlightBlock(
     block.setAttribute("data-highlighted", "true");
     block.setAttribute("data-lang", language);
   } catch (err) {
-    console.warn(`[arborium] Failed to highlight ${language}:`, err);
+    config.logger.warn(`[arborium] Failed to highlight ${language}:`, err);
   }
 }
 
@@ -321,7 +321,7 @@ async function autoHighlight(configOverrides?: Partial<ArboriumConfig>): Promise
   const languages = Array.from(blocksByLanguage.keys());
   const loadPromises = languages.map((lang) =>
     loadGrammar(lang, config).catch((err) => {
-      console.warn(`[arborium] Failed to load grammar for ${lang}:`, err);
+      config.logger.warn(`[arborium] Failed to load grammar for ${lang}:`, err);
       return null;
     }),
   );
@@ -349,7 +349,7 @@ async function autoHighlight(configOverrides?: Partial<ArboriumConfig>): Promise
   const skipped = unknownBlocks.length;
 
   if (highlighted > 0 || skipped > 0) {
-    console.debug(
+    config.logger.debug(
       `[arborium] Highlighted ${highlighted}/${total} blocks` +
         (skipped > 0 ? ` (${skipped} unknown language)` : ""),
     );
@@ -366,8 +366,9 @@ async function onThemeChange(): Promise<void> {
 
   if (currentThemeId !== newTheme) {
     setConfig({ theme: newTheme });
-    injectThemeCSS(getConfig());
-    console.debug(`[arborium] Theme changed to: ${newTheme}`);
+    const config = getConfig();
+    injectThemeCSS(config);
+    config.logger.debug(`[arborium] Theme changed to: ${newTheme}`);
   }
 }
 
@@ -409,7 +410,7 @@ export async function highlightElement(
   const lang = language || getLanguageForBlock(element);
 
   if (!lang) {
-    console.warn("[arborium] Could not detect language for element");
+    config.logger.warn("[arborium] Could not detect language for element");
     return;
   }
 

--- a/packages/arborium/src/loader.ts
+++ b/packages/arborium/src/loader.ts
@@ -14,9 +14,17 @@ import type {
   ArboriumConfig,
   Grammar,
   Session,
+  Logger,
 } from "./types.js";
 import { availableLanguages, pluginVersion } from "./plugins-manifest.js";
 import { escapeHtml } from "./utils.js";
+
+// Default logger using console
+const defaultLogger: Logger = {
+  debug: (...args) => console.debug(...args),
+  info: (...args) => console.info(...args),
+  warn: (...args) => console.warn(...args),
+};
 
 // Default config
 export const defaultConfig: Required<ArboriumConfig> = {
@@ -29,6 +37,7 @@ export const defaultConfig: Required<ArboriumConfig> = {
   hostUrl: "", // Empty means use CDN based on version
   resolveJs: ({ baseUrl, path }) => import(/* @vite-ignore */ `${baseUrl}/${path}`),
   resolveWasm: ({ baseUrl, path }) => fetch(`${baseUrl}/${path}`),
+  logger: defaultLogger,
 };
 
 // Rust host module (loaded on demand)
@@ -73,13 +82,13 @@ async function ensureLocalManifest(config: Required<ArboriumConfig>): Promise<vo
   }
 
   localManifestPromise = (async () => {
-    console.debug(`[arborium] Loading local plugins manifest from: ${config.pluginsUrl}`);
+    config.logger.debug(`[arborium] Loading local plugins manifest from: ${config.pluginsUrl}`);
     const response = await fetch(config.pluginsUrl);
     if (!response.ok) {
       throw new Error(`Failed to load plugins.json: ${response.status}`);
     }
     localManifest = await response.json();
-    console.debug(`[arborium] Loaded local manifest with ${localManifest?.entries.length} entries`);
+    config.logger.debug(`[arborium] Loaded local manifest with ${localManifest?.entries.length} entries`);
   })();
 
   return localManifestPromise;
@@ -153,14 +162,14 @@ async function loadGrammarPlugin(
   // Check cache first
   const cached = grammarCache.get(language);
   if (cached) {
-    console.debug(`[arborium] Grammar '${language}' found in cache`);
+    config.logger.debug(`[arborium] Grammar '${language}' found in cache`);
     return cached;
   }
 
   // Check if there's already an in-flight load for this language
   const inFlight = grammarLoadPromises.get(language);
   if (inFlight) {
-    console.debug(`[arborium] Grammar '${language}' already loading, waiting...`);
+    config.logger.debug(`[arborium] Grammar '${language}' already loading, waiting...`);
     return inFlight;
   }
 
@@ -189,7 +198,7 @@ async function loadGrammarPluginInner(
     !knownLanguages.has(language) &&
     !localManifest?.entries.some((e) => e.language === language)
   ) {
-    console.debug(`[arborium] Grammar '${language}' not available`);
+    config.logger.debug(`[arborium] Grammar '${language}' not available`);
     return null;
   }
 
@@ -197,7 +206,7 @@ async function loadGrammarPluginInner(
     const baseUrl = getGrammarBaseUrl(language, config);
     const detail =
       config.resolveJs === defaultConfig.resolveJs ? ` from ${baseUrl}/grammar.js` : "";
-    console.debug(`[arborium] Loading grammar '${language}'${detail}`);
+    config.logger.debug(`[arborium] Loading grammar '${language}'${detail}`);
 
     const module = (await config.resolveJs({
       language,
@@ -212,13 +221,15 @@ async function loadGrammarPluginInner(
     // Verify it loaded correctly
     const loadedId = module.language_id();
     if (loadedId !== language) {
-      console.warn(`[arborium] Language ID mismatch: expected '${language}', got '${loadedId}'`);
+      config.logger.warn(`[arborium] Language ID mismatch: expected '${language}', got '${loadedId}'`);
     }
 
     // Get injection languages
     const injectionLanguages = module.injection_languages();
 
     // Wrap as GrammarPlugin with session-based parsing
+    // Capture logger reference for use in closures
+    const { logger } = config;
     const plugin: GrammarPlugin = {
       languageId: language,
       injectionLanguages,
@@ -234,7 +245,7 @@ async function loadGrammarPluginInner(
             injections: result.injections || [],
           };
         } catch (e) {
-          console.error(`[arborium] Parse error:`, e);
+          logger.warn(`[arborium] Parse error:`, e);
           return { spans: [], injections: [] };
         } finally {
           module.free_session(session);
@@ -251,7 +262,7 @@ async function loadGrammarPluginInner(
             injections: result.injections || [],
           };
         } catch (e) {
-          console.error(`[arborium] Parse error:`, e);
+          logger.warn(`[arborium] Parse error:`, e);
           return { spans: [], injections: [] };
         } finally {
           module.free_session(session);
@@ -260,10 +271,10 @@ async function loadGrammarPluginInner(
     };
 
     grammarCache.set(language, plugin);
-    console.debug(`[arborium] Grammar '${language}' loaded successfully`);
+    config.logger.debug(`[arborium] Grammar '${language}' loaded successfully`);
     return plugin;
   } catch (e) {
-    console.error(`[arborium] Failed to load grammar '${language}':`, e);
+    config.logger.warn(`[arborium] Failed to load grammar '${language}':`, e);
     return null;
   }
 }
@@ -338,7 +349,7 @@ async function loadHost(config: Required<ArboriumConfig>): Promise<HostModule | 
     const jsUrl = `${hostUrl}/arborium_host.js`;
     const wasmUrl = `${hostUrl}/arborium_host_bg.wasm`;
 
-    console.debug(`[arborium] Loading host from ${jsUrl}`);
+    config.logger.debug(`[arborium] Loading host from ${jsUrl}`);
     try {
       const module = await import(/* @vite-ignore */ jsUrl);
       await module.default(wasmUrl);
@@ -347,10 +358,10 @@ async function loadHost(config: Required<ArboriumConfig>): Promise<HostModule | 
         highlight: module.highlight,
         isLanguageAvailable: module.isLanguageAvailable,
       };
-      console.debug(`[arborium] Host loaded successfully`);
+      config.logger.debug(`[arborium] Host loaded successfully`);
       return hostModule;
     } catch (e) {
-      console.error("[arborium] Failed to load host:", e);
+      config.logger.warn("[arborium] Failed to load host:", e);
       return null;
     }
   })();
@@ -371,7 +382,7 @@ export async function highlight(
     try {
       return host.highlight(language, source);
     } catch (e) {
-      console.error("[arborium] Host highlight failed:", e);
+      config.logger.warn("[arborium] Host highlight failed:", e);
     }
   }
 
@@ -389,6 +400,8 @@ export async function loadGrammar(
   if (!plugin) return null;
 
   const { module } = plugin;
+  // Capture logger reference for use in closures
+  const { logger } = config;
 
   return {
     languageId: () => plugin.languageId,
@@ -412,7 +425,7 @@ export async function loadGrammar(
               injections: result.injections || [],
             };
           } catch (e) {
-            console.error(`[arborium] Session parse error:`, e);
+            logger.warn(`[arborium] Session parse error:`, e);
             return { spans: [], injections: [] };
           }
         },

--- a/packages/arborium/src/types.ts
+++ b/packages/arborium/src/types.ts
@@ -175,6 +175,29 @@ export interface Grammar {
 // Other types
 // ============================================================================
 
+/**
+ * Logger interface for customizing log output.
+ *
+ * By default, arborium uses the global `console` object. You can provide
+ * a custom logger to silence logs or redirect them to your logging system.
+ *
+ * @example
+ * ```ts
+ * // Silence all logs
+ * const silentLogger = { debug: () => {}, info: () => {}, warn: () => {} };
+ * arborium.setConfig({ logger: silentLogger });
+ *
+ * // Use a custom logging library
+ * import { myLogger } from './my-logger';
+ * arborium.setConfig({ logger: myLogger });
+ * ```
+ */
+export interface Logger {
+  debug(...data: unknown[]): void;
+  info(...data: unknown[]): void;
+  warn(...data: unknown[]): void;
+}
+
 /** A highlighting tag */
 export interface Highlight {
   /** Long name, used in `Span` */
@@ -216,6 +239,8 @@ export interface ArboriumConfig {
   resolveJs?(args: ResolveArgs): MaybePromise<unknown>;
   /** Custom grammar resolution for WASM */
   resolveWasm?(args: ResolveArgs): MaybePromise<Response | BufferSource | WebAssembly.Module>;
+  /** Custom logger for debug/info/warn output (defaults to console) */
+  logger?: Logger;
 }
 
 /** Global config set before script loads */


### PR DESCRIPTION
## Summary

Adds a `Logger` interface and `logger` config option to allow users to customize or silence arborium's console output. This addresses the need to control logging behavior in production environments or when integrating with custom logging systems.

## Changes

- Add `Logger` interface in `types.ts` with `debug`, `info`, and `warn` methods
- Add `logger` config option to `ArboriumConfig`
- Create default logger that uses the global `console` object
- Replace all `console.debug/warn/error` calls with `config.logger.*` throughout `iife.ts` and `loader.ts`
- Changed parse error logging from `console.error` to `logger.warn` for consistency

## Usage

```ts
// Silence all logs
const silentLogger = { debug: () => {}, info: () => {}, warn: () => {} };
arborium.setConfig({ logger: silentLogger });

// Use a custom logging library
import { myLogger } from './my-logger';
arborium.setConfig({ logger: myLogger });
```

Fixes #135