### PR TITLE
fix(styx): update highlights.scm to use > for attributes

### DIFF
--- a/langs/group-maple/styx/def/queries/highlights.scm
+++ b/langs/group-maple/styx/def/queries/highlights.scm
@@ -23,7 +23,7 @@
 ; Attributes - key in attribute syntax
 (attribute
   key: (bare_scalar) @property
-  "=" @operator)
+  ">" @operator)
 
 ; Keys in entries - bare scalars in the key position (overrides @string above)
 (entry


### PR DESCRIPTION
## Summary
- Updates highlights.scm to use `>` instead of `=` for attribute separators

The grammar was updated in cdb75ab2 to use `>` instead of `=` for attribute separators, but highlights.scm was not updated to match. This caused query validation to fail with "Invalid node type >", breaking Styx syntax highlighting completely.

## Test plan
- [x] `cargo xtask grammar-test styx` passes