### PR TITLE
Allow host module resolution to be overridden

### DIFF
--- a/packages/arborium/src/index.ts
+++ b/packages/arborium/src/index.ts
@@ -20,6 +20,7 @@ export type {
   Grammar,
   Highlight,
   Injection,
+  LanguageResolveArgs,
   ParseResult,
   ResolveArgs,
   Session,

--- a/packages/arborium/src/types.ts
+++ b/packages/arborium/src/types.ts
@@ -188,12 +188,15 @@ export interface Highlight {
 type MaybePromise<T> = T | Promise<T>;
 
 export interface ResolveArgs {
-  /** Language to load the grammar plugin for */
-  language: string;
   /** Base URL derived from language, CDN and version */
   baseUrl: string;
   /** Relative path in the module to load */
   path: string;
+}
+
+export interface LanguageResolveArgs extends ResolveArgs {
+  /** Language to load the grammar plugin for */
+  language: string;
 }
 
 /** Configuration for the arborium runtime */
@@ -214,10 +217,14 @@ export interface ArboriumConfig {
   hostUrl?: string;
   /** Object to use for logging (default: global.console) */
   logger?: Pick<Console, "debug" | "error" | "warn">;
+  /** Custom host resolution for JS */
+  resolveHostJs?(args: ResolveArgs): MaybePromise<unknown>;
+  /** Custom host resolution for WASM */
+  resolveHostWasm?(args: ResolveArgs): MaybePromise<Response | BufferSource | WebAssembly.Module>;
   /** Custom grammar resolution for JS */
-  resolveJs?(args: ResolveArgs): MaybePromise<unknown>;
+  resolveJs?(args: LanguageResolveArgs): MaybePromise<unknown>;
   /** Custom grammar resolution for WASM */
-  resolveWasm?(args: ResolveArgs): MaybePromise<Response | BufferSource | WebAssembly.Module>;
+  resolveWasm?(args: LanguageResolveArgs): MaybePromise<Response | BufferSource | WebAssembly.Module>;
 }
 
 /** Global config set before script loads */

--- a/xtask/templates/packages_arborium_package.stpl.json
+++ b/xtask/templates/packages_arborium_package.stpl.json
@@ -18,6 +18,13 @@
     "./iife": {
       "import": "./dist/arborium.iife.js"
     },
+    "./arborium_host.js": {
+      "import": "./dist/arborium_host.js",
+      "types": "./dist/arborium_host.d.ts"
+    },
+    "./arborium_host_bg.wasm": {
+      "import": "./dist/arborium_host_bg.wasm"
+    },
     "./themes/alabaster.css": "./dist/themes/alabaster.css",
     "./themes/ayu-dark.css": "./dist/themes/ayu-dark.css",
     "./themes/ayu-light.css": "./dist/themes/ayu-light.css",
@@ -78,7 +85,7 @@
     "build": "vite build && vite build --config vite.config.iife.ts && npm run copy:host",
     "build:esm": "vite build",
     "build:iife": "vite build --config vite.config.iife.ts",
-    "copy:host": "cp ../../demo/pkg/arborium_host.js ../../demo/pkg/arborium_host*.wasm dist/",
+    "copy:host": "cp ../../demo/pkg/arborium_host.js ../../demo/pkg/arborium_host.d.ts ../../demo/pkg/arborium_host*.wasm dist/",
     "dev": "vite",
     "gen:manifest": "cd ../.. && cargo xtask gen-manifest",
     "prepublishOnly": "npm run gen:manifest && npm run build && test -f dist/arborium.iife.js || (echo 'ERROR: dist/arborium.iife.js missing!' && exit 1)",


### PR DESCRIPTION
Related to #143 

Adds the equivalent of the `resolveJs` and `resolveWasm` for the host interface so that arborium can be used fully without a CDN. Also exports the `arborium_host.js` and `arborium_host_bg.wasm` files in the `package.json` so that dynamic imports work with Node.

I opted to duplicate `resolveJs` and `resolveWasm` as `resolveHostJs` and `resolveHostWasm` respectively. I considered repurposing the `language` attribute and denoting `"host"` as a special value. However, I figured this would be the clearest and allow any existing users of `resolveJs` and `resolveWasm` to keep their implementations unchanged and without any special cases.

I believe this should completely resolve #143 since now every part of the dynamic loading is now customizable at runtime.