### PR TITLE
Add Ctrl+F-friendly supported languages list from registry

### DIFF
--- a/demo/styles.css
+++ b/demo/styles.css
@@ -2795,6 +2795,54 @@ footer a:hover {
     fill: currentColor;
 }
 
+.language-directory-label {
+    margin: 1rem 0 0.5rem 0;
+    font-size: 0.85rem;
+    color: var(--muted);
+}
+
+.language-directory {
+    list-style: none;
+    margin: 0 0 1rem 0;
+    padding: 0;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(13rem, 1fr));
+    gap: 0.4rem 0.75rem;
+}
+
+.language-directory-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    min-width: 0;
+    font-size: 0.82rem;
+    color: color-mix(in srgb, var(--fg) 88%, var(--muted));
+}
+
+.language-directory-item .lang-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    width: 1rem;
+    height: 1rem;
+}
+
+.language-directory-item code {
+    margin-left: auto;
+    font-size: 0.72rem;
+    color: var(--muted);
+    background: color-mix(in srgb, var(--accent) 10%, transparent);
+    border-radius: 0.25rem;
+    padding: 0.1rem 0.35rem;
+}
+
+@media (max-width: 42rem) {
+    .language-directory {
+        grid-template-columns: 1fr;
+    }
+}
+
 @keyframes marquee-scroll {
     0% {
         transform: translateX(0);

--- a/xtask/templates/app.stpl.js
+++ b/xtask/templates/app.stpl.js
@@ -991,20 +991,9 @@ async function initialize() {
         }
         registry = await pluginsResponse.json();
 
-        // Get list of available languages from registry
-        allLanguages = registry.entries.map(e => e.language);
-
-        // Sort by tier (lower is better), then by name
-        allLanguages.sort((a, b) => {
-            const infoA = languageInfo[a] || { name: a };
-            const infoB = languageInfo[b] || { name: b };
-            const tierA = infoA.tier ?? 99;
-            const tierB = infoB.tier ?? 99;
-            if (tierA !== tierB) {
-                return tierA - tierB;
-            }
-            return (infoA.name || a).localeCompare(infoB.name || b);
-        });
+        // Build available language list from registry entries (single source of truth)
+        const availableLanguages = getAvailableLanguagesFromRegistry();
+        allLanguages = availableLanguages.map((lang) => lang.id);
 
         wasmLoaded = true;
 
@@ -1020,6 +1009,8 @@ async function initialize() {
 
         // Initialize size comparison table
         initSizeTable();
+        populateLangMarquee(availableLanguages);
+        populateLanguageDirectory(availableLanguages);
 
     } catch (error) {
         console.error('Failed to initialize:', error);
@@ -1073,6 +1064,34 @@ async function doHighlight() {
 function updateStatus(message, success) {
     // Status is now used for attribution, not messages
     // This function is kept for backwards compatibility but does nothing
+}
+
+function getAvailableLanguagesFromRegistry() {
+    if (!registry?.entries) return [];
+
+    const seen = new Set();
+    const languages = [];
+
+    for (const entry of registry.entries) {
+        const id = entry.language;
+        if (!id || seen.has(id)) continue;
+        seen.add(id);
+        const info = languageInfo[id] || {};
+        languages.push({
+            id,
+            name: info.name || id,
+            tier: info.tier ?? 99,
+        });
+    }
+
+    languages.sort((a, b) => {
+        if (a.tier !== b.tier) {
+            return a.tier - b.tier;
+        }
+        return a.name.localeCompare(b.name);
+    });
+
+    return languages;
 }
 
 function updateAttribution() {
@@ -1184,17 +1203,17 @@ document.addEventListener('keydown', (e) => {
 });
 
 // Populate language marquee
-function populateLangMarquee() {
+function populateLangMarquee(languages) {
     const marquee = document.getElementById('lang-marquee');
-    if (!marquee) return;
-
-    // Get all language names sorted alphabetically
-    const langNames = Object.entries(languageInfo)
-        .map(([id, info]) => ({ id, name: info.name || id, icon: info.icon }))
-        .sort((a, b) => a.name.localeCompare(b.name));
+    if (!marquee) return [];
+    const languageList = languages || getAvailableLanguagesFromRegistry();
+    if (languageList.length === 0) {
+        marquee.innerHTML = '';
+        return [];
+    }
 
     // Create items - duplicate the list for seamless scrolling
-    const createItems = () => langNames.map(lang => {
+    const createItems = () => languageList.map(lang => {
         const iconSvg = getIconSvg(lang.id);
         return `<span class="lang-marquee-item">${iconSvg}${lang.name}</span>`;
     }).join('');
@@ -1205,7 +1224,7 @@ function populateLangMarquee() {
     // Update lang count
     const langCount = document.getElementById('lang-count');
     if (langCount) {
-        langCount.textContent = langNames.length;
+        langCount.textContent = languageList.length;
     }
 
     // Update tagline
@@ -1213,6 +1232,23 @@ function populateLangMarquee() {
     if (tagline) {
         tagline.textContent = `— regex hater club`;
     }
+
+    return languageList;
+}
+
+function populateLanguageDirectory(languages) {
+    const list = document.getElementById('language-directory');
+    if (!list) return;
+
+    if (!languages || languages.length === 0) {
+        list.innerHTML = '';
+        return;
+    }
+
+    list.innerHTML = languages.map((lang) => {
+        const iconSvg = getIconSvg(lang.id);
+        return `<li class="language-directory-item"><span class="lang-icon">${iconSvg}</span><span>${lang.name}</span><code>${lang.id}</code></li>`;
+    }).join('');
 }
 
 // Random button - randomize language and theme together
@@ -1401,4 +1437,3 @@ function initSizeTable() {
 }
 
 initialize();
-populateLangMarquee();

--- a/xtask/templates/index.stpl.html
+++ b/xtask/templates/index.stpl.html
@@ -369,6 +369,8 @@
                     <div class="lang-marquee-container">
                         <div class="lang-marquee" id="lang-marquee"></div>
                     </div>
+                    <p class="language-directory-label">Supported languages (Ctrl+F friendly):</p>
+                    <ul class="language-directory" id="language-directory"></ul>
                     <p>
                         Each feature flag comment includes the grammar's license, so you always know
                         what you're shipping.


### PR DESCRIPTION
## Summary
Add a Ctrl+F-friendly supported languages directory to the website Languages section.

## Changes
- Add a static supported-languages list to the Languages card
- Generate the list from `registry.entries` (deduped + sorted)
- Reuse the same registry-derived list for:
  - `allLanguages`
  - marquee population
  - language count
- Add responsive styles for the new language directory

## Validation
- `cargo check` (run in `xtask/`)

Closes #160
