### PR TITLE
Fix XML WASM crash in Node

### DIFF
--- a/langs/group-acorn/xml/def/arborium.yaml
+++ b/langs/group-acorn/xml/def/arborium.yaml
@@ -1,5 +1,5 @@
 repo: https://github.com/tree-sitter-grammars/tree-sitter-xml
-commit: 863dbc381f44f6c136a399e684383b977bb2beaa
+commit: 5000ae8f22d11fbe93939b05c1e37cf21117162d
 license: MIT
 
 grammars:

--- a/langs/group-acorn/xml/def/grammar/scanner.c
+++ b/langs/group-acorn/xml/def/grammar/scanner.c
@@ -48,7 +48,8 @@ static bool scan_end_tag_name(Vector *tags, TSLexer *lexer) {
     }
 
     if (tags->size > 0 && string_eq(array_back(tags), &tag_name)) {
-        array_delete(&array_pop(tags));
+        String last_tag = array_pop(tags);
+        array_delete(&last_tag);
         lexer->result_symbol = END_TAG_NAME;
     } else {
         lexer->result_symbol = ERRONEOUS_END_NAME;
@@ -61,7 +62,8 @@ static bool scan_self_closing_tag_delimiter(Vector *tags, TSLexer *lexer) {
     advance(lexer);
     advance_if_eq(lexer, '>');
     if (tags->size > 0) {
-        array_delete(&array_pop(tags));
+        String last_tag = array_pop(tags);
+        array_delete(&last_tag);
         lexer->result_symbol = SELF_CLOSING_TAG_DELIMITER;
     }
     return true;

--- a/xtask/templates/plugin_lib.stpl.rs
+++ b/xtask/templates/plugin_lib.stpl.rs
@@ -9,7 +9,7 @@ thread_local! {
     static RUNTIME: RefCell<Option<PluginRuntime>> = const { RefCell::new(None) };
 }
 
-fn get_or_init_runtime() -> &'static RefCell<Option<PluginRuntime>> {
+fn with_runtime<T>(f: impl FnOnce(&mut PluginRuntime) -> T) -> T {
     RUNTIME.with(|r| {
         let mut runtime = r.borrow_mut();
         if runtime.is_none() {
@@ -23,7 +23,7 @@ fn get_or_init_runtime() -> &'static RefCell<Option<PluginRuntime>> {
             .expect("failed to create highlight config");
             *runtime = Some(PluginRuntime::new(config));
         }
-        unsafe { &*(r as *const _) }
+        f(runtime.as_mut().expect("runtime not initialized"))
     })
 }
 
@@ -43,31 +43,19 @@ pub fn injection_languages() -> Vec<String> {
 /// Creates a new parser session and returns its ID.
 #[wasm_bindgen]
 pub fn create_session() -> u32 {
-    get_or_init_runtime()
-        .borrow_mut()
-        .as_mut()
-        .expect("runtime not initialized")
-        .create_session()
+    with_runtime(|runtime| runtime.create_session())
 }
 
 /// Frees a parser session.
 #[wasm_bindgen]
 pub fn free_session(session: u32) {
-    get_or_init_runtime()
-        .borrow_mut()
-        .as_mut()
-        .expect("runtime not initialized")
-        .free_session(session);
+    with_runtime(|runtime| runtime.free_session(session));
 }
 
 /// Sets the text for a parser session.
 #[wasm_bindgen]
 pub fn set_text(session: u32, text: &str) {
-    get_or_init_runtime()
-        .borrow_mut()
-        .as_mut()
-        .expect("runtime not initialized")
-        .set_text(session, text);
+    with_runtime(|runtime| runtime.set_text(session, text));
 }
 
 /// Parses the text in a session and returns spans with UTF-8 byte offsets.
@@ -76,11 +64,7 @@ pub fn set_text(session: u32, text: &str) {
 /// For JavaScript interop, use `parse_utf16` instead.
 #[wasm_bindgen]
 pub fn parse(session: u32) -> Result<JsValue, JsValue> {
-    let result: Result<Utf8ParseResult, _> = get_or_init_runtime()
-        .borrow_mut()
-        .as_mut()
-        .expect("runtime not initialized")
-        .parse(session);
+    let result: Result<Utf8ParseResult, _> = with_runtime(|runtime| runtime.parse(session));
 
     match result {
         Ok(r) => serde_wasm_bindgen::to_value(&r)
@@ -95,11 +79,7 @@ pub fn parse(session: u32) -> Result<JsValue, JsValue> {
 /// The offsets are compatible with JavaScript string APIs.
 #[wasm_bindgen]
 pub fn parse_utf16(session: u32) -> Result<JsValue, JsValue> {
-    let result: Result<Utf16ParseResult, _> = get_or_init_runtime()
-        .borrow_mut()
-        .as_mut()
-        .expect("runtime not initialized")
-        .parse_utf16(session);
+    let result: Result<Utf16ParseResult, _> = with_runtime(|runtime| runtime.parse_utf16(session));
 
     match result {
         Ok(r) => serde_wasm_bindgen::to_value(&r)
@@ -111,9 +91,5 @@ pub fn parse_utf16(session: u32) -> Result<JsValue, JsValue> {
 /// Cancels an ongoing parse operation.
 #[wasm_bindgen]
 pub fn cancel(session: u32) {
-    get_or_init_runtime()
-        .borrow_mut()
-        .as_mut()
-        .expect("runtime not initialized")
-        .cancel(session);
+    with_runtime(|runtime| runtime.cancel(session));
 }


### PR DESCRIPTION
## Summary
- update the vendored XML grammar commit to upstream scanner fix `5000ae8`
- fix the XML scanner UB by deleting popped tag strings via a local variable
- stop returning a thread-local `RefCell` as `'static` in generated wasm plugin glue

## Repro
- reproduced issue #166 locally with the published Node reproducer
- confirmed the crash still happened against Arborium's locally built XML plugin before the fix
- confirmed the repro succeeds after these changes on Node 22.22.0

## Notes
- the XML fix matches upstream `tree-sitter-grammars/tree-sitter-xml` commit `5000ae8f22d11fbe93939b05c1e37cf21117162d`
- the plugin template change fixes a separate borrow bug that caused cascading cleanup panics once the primary scanner crash occurred
