### PR TITLE
feat: loader: pass version to resolveJs and resolveWasm

### DIFF
--- a/packages/arborium/src/loader.ts
+++ b/packages/arborium/src/loader.ts
@@ -197,17 +197,14 @@ async function loadGrammarPluginInner(
   }
 
   try {
+    const version = config.version;
     const baseUrl = getGrammarBaseUrl(language, config);
     const detail =
       config.resolveJs === defaultConfig.resolveJs ? ` from ${baseUrl}/grammar.js` : "";
     config.logger.debug(`[arborium] Loading grammar '${language}'${detail}`);
 
-    const module = (await config.resolveJs({
-      language,
-      baseUrl,
-      path: "grammar.js",
-    })) as WasmBindgenPlugin;
-    const wasm = await config.resolveWasm({ language, baseUrl, path: "grammar_bg.wasm" });
+    const module = (await config.resolveJs({ language, baseUrl, version, path: "grammar.js", })) as WasmBindgenPlugin;
+    const wasm = await config.resolveWasm({ language, baseUrl, version, path: "grammar_bg.wasm" });
 
     // Initialize the WASM module
     await module.default({ module_or_path: wasm });


### PR DESCRIPTION
by default `version` will be in `baseUrl` and this key will go unused but overriders to this method will not being using `baseUrl` in their resolution and thus will need `version` on its own to keep resources in sync