### PR TITLE
Add Makefile language support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -457,7 +457,7 @@ jobs:
           path: dist/plugins
           retention-days: "7"
   build-plugins-maple: 
-    name: "Plugins (maple): caddy, cmake, dockerfile, dot, graphql, hcl, ini, jq, meson, nginx, ninja, nix, query, rego, ron, sql, ssh-config, styx, toml, yaml"
+    name: "Plugins (maple): caddy, cmake, dockerfile, dot, graphql, hcl, ini, jq, makefile, meson, nginx, ninja, nix, query, rego, ron, sql, ssh-config, styx, toml, yaml"
     runs-on: depot-ubuntu-24.04-32
     container: "ghcr.io/bearcove/arborium-plugin-builder:latest"
     needs: 
@@ -475,10 +475,10 @@ jobs:
           set -e
           tar -xf generate-output.tar && rm generate-output.tar
         shell: bash
-      - name: Build caddy, cmake, dockerfile, dot, graphql, hcl, ini, jq, meson, nginx, ninja, nix, query, rego, ron, sql, ssh-config, styx, toml, yaml
+      - name: Build caddy, cmake, dockerfile, dot, graphql, hcl, ini, jq, makefile, meson, nginx, ninja, nix, query, rego, ron, sql, ssh-config, styx, toml, yaml
         run: |-
           set -e
-          ./xtask/target/release/xtask build caddy cmake dockerfile dot graphql hcl ini jq meson nginx ninja nix query rego ron sql ssh-config styx toml yaml -o dist/plugins
+          ./xtask/target/release/xtask build caddy cmake dockerfile dot graphql hcl ini jq makefile meson nginx ninja nix query rego ron sql ssh-config styx toml yaml -o dist/plugins
         shell: bash
       - name: Upload plugins artifact
         uses: actions/upload-artifact@v4

--- a/LICENSES.md
+++ b/LICENSES.md
@@ -22,6 +22,7 @@ You may choose either license at your option.
 | tree-sitter-diff | MIT | Copyright (c) 2021 Michael Davis |
 | tree-sitter-dockerfile | MIT | Copyright (c) 2021 Camden Cheek |
 | tree-sitter-ini | Apache-2.0 | Copyright Justin M. Keyes |
+| tree-sitter-make | MIT | Copyright (c) 2021 Alexandre A. Muller |
 | tree-sitter-meson | MIT | Copyright (c) 2023 Decodertalkers |
 | tree-sitter-nix | MIT | Copyright (c) 2019 Charles Strahan |
 | tree-sitter-scss | MIT | Copyright (c) 2024 Amaan Qureshi |

--- a/langs/group-maple/makefile/def/arborium.yaml
+++ b/langs/group-maple/makefile/def/arborium.yaml
@@ -1,0 +1,27 @@
+repo: https://github.com/tree-sitter-grammars/tree-sitter-make
+commit: 70613f3d812cbabbd7f38d104d60a409c4008b43
+license: MIT
+
+grammars:
+  - id: makefile
+    name: Makefile
+    tag: config
+    tier: 3
+    has_scanner: false
+    generate_plugin: true
+    c_symbol: make
+    icon: simple-icons:gnu
+    aliases:
+      - make
+      - mk
+
+    inventor: Stuart Feldman
+    year: 1976
+    description: 'Build automation language used by GNU make and BSD make to describe how to derive targets from sources via shell rules; see the <a href="https://www.gnu.org/software/make/manual/make.html">GNU make manual</a>.'
+    trivia: "Stuart Feldman wrote make at Bell Labs in 1976; the tab-indented recipe rule was reportedly preserved decades later because too many existing makefiles depended on it."
+    link: https://en.wikipedia.org/wiki/Make_(software)
+
+    samples:
+      - path: samples/example.mk
+        description: Makefile with variables, pattern rules, conditionals, automatic variables, and the shell function.
+        license: MIT

--- a/langs/group-maple/makefile/def/grammar/grammar.js
+++ b/langs/group-maple/makefile/def/grammar/grammar.js
@@ -1,0 +1,643 @@
+/**
+ * @file Make grammar for tree-sitter
+ * @author Alexandre Muller
+ * @author Amaan Qureshi <amaanq12@gmail.com>
+ * @license MIT
+ */
+
+/// <reference types="tree-sitter-cli/dsl" />
+// @ts-check
+
+const CHARSET = 'a-zA-Z0-9%\\+\\-\\.@_\\*\\?\\/';
+const ESCAPE_SET = 'abtnvfrE!"#\\$&\'\\(\\)\\*,;<>\\?\\[\\\\\\]^`{\\|}~';
+
+const NL = token.immediate(/[\r\n]+/);
+const WS = token.immediate(/[\t ]+/);
+const SPLIT = alias(token.immediate(seq('\\', /\r?\n|\r/)), '\\');
+
+const AUTOMATIC_VARS = ['@', '%', '<', '?', '^', '+', '/', '*'];
+
+const DEFINE_OPS = ['=', ':=', '::=', '?=', '+='];
+
+const FUNCTIONS = [
+  'subst',
+  'patsubst',
+  'strip',
+  'findstring',
+  'filter',
+  'filter-out',
+  'sort',
+  'word',
+  'words',
+  'wordlist',
+  'firstword',
+  'lastword',
+  'dir',
+  'notdir',
+  'suffix',
+  'basename',
+  'addsuffix',
+  'addprefix',
+  'join',
+  'wildcard',
+  'realpath',
+  'abspath',
+  'error',
+  'warning',
+  'info',
+  'origin',
+  'flavor',
+  'foreach',
+  'if',
+  'or',
+  'and',
+  'intcmp',
+  'let',
+  'call',
+  'eval',
+  'file',
+  'value',
+  'guile',
+];
+
+export default grammar({
+  name: 'make',
+
+  word: $ => $.word,
+
+  inline: $ => [
+    $._targets,
+    $._target_pattern,
+    $._prerequisites_pattern,
+    $._prerequisites,
+    $._order_only_prerequisites,
+    $._target_or_pattern_assignment,
+
+    $._primary,
+    $._name,
+    $._string,
+  ],
+
+  extras: $ => [
+    /\s/,
+    alias(token(seq('\\', /\r?\n|\r/)), '\\'),
+    $.comment,
+  ],
+
+  rules: {
+    // 3.1
+    makefile: $ => repeat($._thing),
+
+    _thing: $ => choice(
+      $.rule,
+      $._variable_definition,
+      $._directive,
+      seq($._function, NL),
+    ),
+
+    // Rules {{{
+    // 2.1
+    rule: $ => choice(
+      $._ordinary_rule,
+      $._static_pattern_rule,
+    ),
+
+    _ordinary_rule: $ => prec.right(seq(
+      $._targets,
+      choice(':', '&:', '::'),
+      optional(WS),
+      optional($._prerequisites),
+      choice(
+        $.recipe,
+        NL,
+      ),
+    )),
+
+    // 4.12.1
+    _static_pattern_rule: $ => prec.right(seq(
+      $._targets,
+      ':',
+      optional(WS),
+      $._target_pattern,
+      ':',
+      optional(WS),
+      optional($._prerequisites_pattern),
+      choice(
+        $.recipe,
+        NL,
+      ),
+    )),
+
+    _targets: $ => alias($.list, $.targets),
+
+    // LINT: List shall have length one
+    _target_pattern: $ => field(
+      'target',
+      alias($.list, $.pattern_list),
+    ),
+
+    // 4.3
+    _prerequisites: $ => choice(
+      $._normal_prerequisites,
+      seq(
+        optional($._normal_prerequisites),
+        '|',
+        $._order_only_prerequisites,
+      ),
+    ),
+
+    _normal_prerequisites: $ => field(
+      'normal',
+      alias($.list, $.prerequisites),
+    ),
+
+    _order_only_prerequisites: $ => field(
+      'order_only',
+      alias($.list, $.prerequisites),
+    ),
+
+    _prerequisites_pattern: $ => field(
+      'prerequisite',
+      alias($.list, $.pattern_list),
+    ),
+
+    recipe: $ => prec.right(choice(
+      // the first recipe line may be attached to the
+      // target-and-prerequisites line with a semicolon
+      // in between
+      seq(
+        $._attached_recipe_line,
+        NL,
+        repeat(choice(
+          $.conditional,
+          $._prefixed_recipe_line,
+        )),
+      ),
+      seq(
+        NL,
+        repeat1(choice(
+          $.conditional,
+          $._prefixed_recipe_line,
+        )),
+      ),
+    )),
+
+    _attached_recipe_line: $ => seq(
+      ';',
+      optional($.recipe_line),
+    ),
+
+    _prefixed_recipe_line: $ => seq(
+      $._recipeprefix,
+      optional($.recipe_line),
+      NL,
+    ),
+
+    recipe_line: $ => seq(
+      optional(choice(
+        ...['@', '-', '+'].map(c => token(prec(1, c))),
+      )),
+      alias($._line_text, $.shell_text),
+    ),
+    // }}}
+    // Variables {{{
+    _variable_definition: $ => choice(
+      $.VPATH_assignment,
+      $.RECIPEPREFIX_assignment,
+      $.variable_assignment,
+      $.shell_assignment,
+      $.define_directive,
+    ),
+
+    // 4.5.1
+    VPATH_assignment: $ => seq(
+      field('name', 'VPATH'),
+      optional(WS),
+      field('operator', choice(...DEFINE_OPS)),
+      field('value', $.paths),
+      NL,
+    ),
+
+    RECIPEPREFIX_assignment: $ => seq(
+      field('name', '.RECIPEPREFIX'),
+      optional(WS),
+      field('operator', choice(...DEFINE_OPS)),
+      field('value', alias($._assignment_text, $.text)),
+      NL,
+    ),
+
+    // 6.5
+    variable_assignment: $ => seq(
+      optional($._target_or_pattern_assignment),
+      $._name,
+      optional(WS),
+      field('operator', choice(...DEFINE_OPS)),
+      optional(WS),
+      optional(field('value', alias($._assignment_text, $.text))),
+      NL,
+    ),
+
+    _target_or_pattern_assignment: $ => seq(
+      field('target_or_pattern', $.list),
+      ':',
+      optional(WS),
+    ),
+
+    shell_assignment: $ => seq(
+      field('name', $.word),
+      optional(WS),
+      field('operator', '!='),
+      optional(WS),
+      field('value', alias($._line_text, $.shell_command)),
+      NL,
+    ),
+
+    define_directive: $ => seq(
+      'define',
+      field('name', $.word),
+      optional(WS),
+      optional(field('operator', choice(...DEFINE_OPS))),
+      optional(WS),
+      NL,
+      optional(field('value',
+        alias(repeat1($._rawline), $.raw_text),
+      )),
+      token(prec(1, 'endef')),
+      NL,
+    ),
+    // }}}
+    // Directives {{{
+    _directive: $ => choice(
+      $.include_directive,
+      $.vpath_directive,
+      $.export_directive,
+      $.unexport_directive,
+      $.override_directive,
+      $.undefine_directive,
+      $.private_directive,
+      $.conditional,
+    ),
+
+    // 3.3
+    include_directive: $ => choice(
+      seq('include', field('filenames', $.list), NL),
+      seq('sinclude', field('filenames', $.list), NL),
+      seq('-include', field('filenames', $.list), NL),
+    ),
+
+    // 4.5.2
+    vpath_directive: $ => choice(
+      seq('vpath', NL),
+      seq('vpath', field('pattern', $.word), NL),
+      seq('vpath', field('pattern', $.word), field('directories', $.paths), NL),
+    ),
+
+    // 5.7.2
+    export_directive: $ => choice(
+      seq('export', NL),
+      seq('export', field('variables', $.list), NL),
+      seq('export', $.variable_assignment),
+    ),
+
+    // 5.7.2
+    unexport_directive: $ => choice(
+      seq('unexport', NL),
+      seq('unexport', field('variables', $.list), NL),
+    ),
+
+    // 6.7
+    override_directive: $ => choice(
+      seq('override', $.define_directive),
+      seq('override', $.variable_assignment),
+      seq('override', $.undefine_directive),
+    ),
+
+    // 6.9
+    undefine_directive: $ => seq(
+      'undefine', field('variable', $.word), NL,
+    ),
+
+    // 6.13
+    private_directive: $ => seq(
+      'private', $.variable_assignment,
+    ),
+    // }}}
+    // Conditionals {{{
+    // 7
+    conditional: $ => seq(
+      field('condition', $._conditional_directives),
+      optional(field('consequence', $._conditional_consequence)),
+      repeat($.elsif_directive),
+      optional($.else_directive),
+      'endif',
+      NL,
+    ),
+
+    elsif_directive: $ => seq(
+      'else',
+      field('condition', $._conditional_directives),
+      optional(field('consequence', $._conditional_consequence)),
+    ),
+
+    else_directive: $ => seq(
+      'else',
+      NL,
+      optional(field('consequence', $._conditional_consequence)),
+    ),
+
+    _conditional_directives: $ => choice(
+      $.ifeq_directive,
+      $.ifneq_directive,
+      $.ifdef_directive,
+      $.ifndef_directive,
+    ),
+
+    _conditional_consequence: $ => repeat1(choice(
+      $._thing,
+      $._prefixed_recipe_line,
+    )),
+
+    ifeq_directive: $ => seq(
+      'ifeq', $._conditional_args_cmp, NL,
+    ),
+
+    ifneq_directive: $ => seq(
+      'ifneq', $._conditional_args_cmp, NL,
+    ),
+
+    ifdef_directive: $ => seq(
+      'ifdef', field('variable', $._primary), NL,
+    ),
+
+    ifndef_directive: $ => seq(
+      'ifndef', field('variable', $._primary), NL,
+    ),
+
+    _conditional_args_cmp: $ => choice(
+      seq(
+        '(',
+        optional(field('arg0', $._primary)),
+        ',',
+        optional(field('arg1', $._primary)),
+        ')',
+      ),
+      seq(
+        field('arg0', $._primary),
+        field('arg1', $._primary),
+      ),
+    ),
+
+    // }}}
+    // Variables {{{
+    _variable: $ => choice(
+      $.variable_reference,
+      $.substitution_reference,
+      $.automatic_variable,
+    ),
+
+    variable_reference: $ => seq(
+      choice('$', '$$'),
+      choice(
+        delimitedVariable($._primary),
+        // TODO are those legal? $) $$$
+        alias(token.immediate(/./), $.word), // match any single digit
+        // alias(token.immediate('\\\n'), $.word)
+      ),
+    ),
+
+    // 6.3.1
+    substitution_reference: $ => seq(
+      choice('$', '$$'),
+      delimitedVariable(seq(
+        field('text', $._primary),
+        ':',
+        field('pattern', $._primary),
+        '=',
+        field('replacement', $._primary),
+      )),
+    ),
+
+    // 10.5.3
+    automatic_variable: _ => seq(
+      choice('$', '$$'),
+      choice(
+        choice(
+          ...AUTOMATIC_VARS
+            .map(c => token.immediate(prec(1, c))),
+        ),
+        delimitedVariable(seq(
+          choice(
+            ...AUTOMATIC_VARS
+              .map(c => token(prec(1, c))),
+          ),
+          optional(choice(
+            token.immediate('D'),
+            token.immediate('F'),
+          )),
+        )),
+      ),
+    ),
+    // }}}
+    // Functions {{{
+    _function: $ => choice(
+      $.function_call,
+      $.shell_function,
+    ),
+
+    function_call: $ => seq(
+      choice('$', '$$'),
+      token.immediate('('),
+      field('function', choice(
+        ...FUNCTIONS.map(f => token.immediate(f)),
+      )),
+      optional(WS),
+      $.arguments,
+      ')',
+    ),
+
+    arguments: $ => seq(
+      field('argument', $.text),
+      repeat(seq(
+        ',',
+        field('argument', $.text),
+      )),
+    ),
+
+    // 8.13
+    shell_function: $ => seq(
+      choice('$', '$$'),
+      token.immediate('('),
+      field('function', 'shell'),
+      optional(WS),
+      alias($._paren_text, $.shell_command),
+      ')',
+    ),
+    // }}}
+    // Primary and lists {{{
+    list: $ => prec(1, seq(
+      $._primary,
+      repeat(seq(
+        choice(WS, SPLIT),
+        $._primary,
+      )),
+      optional(WS),
+    )),
+
+    paths: $ => seq(
+      $._primary,
+      repeat(seq(
+        choice(...[':', ';'].map(c => token.immediate(c))),
+        $._primary,
+      )),
+    ),
+
+    _primary: $ => choice(
+      $.word,
+      $.archive,
+      $._variable,
+      $._function,
+      $.concatenation,
+      $.string,
+    ),
+
+    concatenation: $ => prec.right(seq(
+      $._primary,
+      repeat1(prec.left($._primary)),
+    )),
+    // }}}
+    // Names {{{
+    _name: $ => field('name', $.word),
+
+    string: $ => field('string', choice(
+      seq('"', optional($._string), '"'),
+      seq('\'', optional($._string), '\''),
+    )),
+
+    _string: $ => repeat1(choice(
+      $._variable,
+      $._function,
+      token(prec(-1, /([^'"$\r\n\\]|\\\\|\\[^\r\n])+/)),
+    )),
+
+    word: _ => token(repeat1(choice(
+      new RegExp('[' + CHARSET + ']'),
+      new RegExp('\\\\[' + ESCAPE_SET + ']'),
+      new RegExp('\\\\[0-9]{3}'),
+    ))),
+
+    // 11.1
+    archive: $ => seq(
+      field('archive', $.word),
+      token.immediate('('),
+      field('members', $.list),
+      token.immediate(')'),
+    ),
+    // }}}
+    // Tokens {{{
+    // TODO external parser for .RECIPEPREFIX
+    _recipeprefix: _ => '\t',
+
+    // TODO prefixed line in define is recipe
+    _rawline: _ => token(/.*[\r\n]+/), // any line
+
+    _paren_group: $ => seq(
+      '(',
+      optional($._paren_text),
+      ')',
+    ),
+
+    _line_text: $ => makeText($, {
+      disallow: ['\\$', '\\n', '\\r', '\\'],
+      allowSplit: true,
+    }),
+
+    // Disallow unescaped # so trailing comments tokenize correctly in assignments.
+    _assignment_text: $ => makeText($, {
+      disallow: ['\\$', '\\n', '\\r', '\\', '#'],
+      allowSplit: true,
+    }),
+
+    _paren_text: $ => makeText($, {
+      disallow: ['\\$', '\\(', '\\)', '\\n', '\\r', '\\'],
+      allowSplit: true,
+      extraFenced: [$._paren_group],
+    }),
+
+    text: $ => $._paren_text,
+    // }}}
+
+    comment: _ => token(prec(-1, /#.*/)),
+  },
+});
+
+/**
+ *
+ * @param {...any} characters
+ */
+function noneOf(...characters) {
+  const negatedString = characters.map(c => c == '\\' ? '\\\\' : c).join('');
+  return new RegExp('[^' + negatedString + ']');
+}
+
+/**
+ *
+ * @param {RuleOrLiteral} rule
+ */
+function delimitedVariable(rule) {
+  return choice(
+    seq(token.immediate('('), rule, ')'),
+    seq(token.immediate('{'), rule, '}'),
+  );
+}
+
+/**
+ *
+ * @param {GrammarSymbols<string>} $
+ * @param {{ disallow: string[], allowSplit?: boolean, extraFenced?: RuleOrLiteral[] }} opts
+ */
+function makeText($, opts) {
+  const rawText = opts.allowSplit ?
+    choice(noneOf(...opts.disallow), SPLIT) :
+    noneOf(...opts.disallow);
+
+  const fencedVars = choice(
+    $._variable,
+    $._function,
+    alias('$$', $.escape),
+    alias('//', $.escape),
+    ...(opts.extraFenced ?? []),
+  );
+
+  return text(rawText, fencedVars);
+}
+
+/**
+ *
+ * @param {RuleOrLiteral} text
+ * @param {RuleOrLiteral} fenced_vars
+ */
+function text(text, fenced_vars) {
+  const raw_text = token(repeat1(choice(
+    text,
+    new RegExp('\\\\[' + ESCAPE_SET + ']'),
+    new RegExp('\\\\[0-9]{3}'),
+    new RegExp('\\\\[^\n\r]'), // used in cmd like sed \1
+  )));
+  return choice(
+    seq(
+      raw_text,
+      repeat(seq(
+        fenced_vars,
+        optional(raw_text),
+      )),
+    ),
+    seq(
+      fenced_vars,
+      repeat(seq(
+        optional(raw_text),
+        fenced_vars,
+      )),
+      optional(raw_text),
+    ),
+  );
+}

--- a/langs/group-maple/makefile/def/queries/highlights.scm
+++ b/langs/group-maple/makefile/def/queries/highlights.scm
@@ -1,0 +1,172 @@
+(comment) @comment @spell
+
+(conditional
+  (_
+    [
+      "ifeq"
+      "else"
+      "ifneq"
+      "ifdef"
+      "ifndef"
+    ] @keyword.conditional)
+  "endif" @keyword.conditional)
+
+(rule
+  (targets
+    (word) @function))
+
+(rule
+  (targets) @_target
+  (prerequisites
+    (word) @function
+    (#eq? @_target ".PHONY")))
+
+(rule
+  (targets
+    (word) @function.builtin
+    (#any-of? @function.builtin
+      ".DEFAULT" ".SUFFIXES" ".DELETE_ON_ERROR" ".EXPORT_ALL_VARIABLES" ".IGNORE" ".INTERMEDIATE"
+      ".LOW_RESOLUTION_TIME" ".NOTPARALLEL" ".ONESHELL" ".PHONY" ".POSIX" ".PRECIOUS" ".SECONDARY"
+      ".SECONDEXPANSION" ".SILENT" ".SUFFIXES")))
+
+(rule
+  [
+    "&:"
+    ":"
+    "::"
+    "|"
+  ] @operator)
+
+[
+  "export"
+  "unexport"
+] @keyword.import
+
+(override_directive
+  "override" @keyword)
+
+(include_directive
+  [
+    "include"
+    "-include"
+  ] @keyword.import
+  filenames: (list
+    (word) @string.special.path))
+
+(variable_assignment
+  name: (word) @string.special.symbol
+  [
+    "?="
+    ":="
+    "::="
+    ; ":::="
+    "+="
+    "="
+  ] @operator)
+
+(shell_assignment
+  name: (word) @string.special.symbol
+  "!=" @operator)
+
+(define_directive
+  "define" @keyword
+  name: (word) @string.special.symbol
+  [
+    "="
+    ":="
+    "::="
+    ; ":::="
+    "?="
+    "!="
+  ]? @operator
+  "endef" @keyword)
+
+(variable_assignment
+  (word) @variable.builtin
+  (#any-of? @variable.builtin
+    ".DEFAULT_GOAL" ".EXTRA_PREREQS" ".FEATURES" ".INCLUDE_DIRS" ".RECIPEPREFIX" ".SHELLFLAGS"
+    ".VARIABLES" "MAKEARGS" "MAKEFILE_LIST" "MAKEFLAGS" "MAKE_RESTARTS" "MAKE_TERMERR"
+    "MAKE_TERMOUT" "SHELL"))
+
+; Use string to match bash
+(variable_reference
+  (word) @string) @operator
+
+(shell_function
+  [
+    "$"
+    "("
+    ")"
+  ] @operator
+  "shell" @function.builtin)
+
+(function_call
+  [
+    "$"
+    "("
+    ")"
+  ] @operator)
+
+(substitution_reference
+  [
+    "$"
+    "("
+    ")"
+  ] @operator)
+
+(automatic_variable
+  "$"
+  _ @character.special
+  (#set! priority 105))
+
+(automatic_variable
+  [
+    "$"
+    "("
+    ")"
+  ] @operator
+  (#set! priority 105))
+
+(recipe_line
+  "@" @character.special)
+
+(function_call
+  [
+    "subst"
+    "patsubst"
+    "strip"
+    "findstring"
+    "filter"
+    "filter-out"
+    "sort"
+    "word"
+    "words"
+    "wordlist"
+    "firstword"
+    "lastword"
+    "dir"
+    "notdir"
+    "suffix"
+    "basename"
+    "addsuffix"
+    "addprefix"
+    "join"
+    "wildcard"
+    "realpath"
+    "abspath"
+    "error"
+    "warning"
+    "info"
+    "origin"
+    "flavor"
+    "foreach"
+    "if"
+    "or"
+    "and"
+    "call"
+    "eval"
+    "file"
+    "value"
+  ] @function.builtin)
+
+"\\" @punctuation.special

--- a/langs/group-maple/makefile/def/queries/injections.scm
+++ b/langs/group-maple/makefile/def/queries/injections.scm
@@ -1,0 +1,5 @@
+((shell_text) @injection.content
+  (#set! injection.language "bash"))
+
+((shell_command) @injection.content
+  (#set! injection.language "bash"))

--- a/langs/group-maple/makefile/def/samples/example.mk
+++ b/langs/group-maple/makefile/def/samples/example.mk
@@ -1,0 +1,56 @@
+# Variables
+CC      := clang
+CFLAGS  := -O2 -Wall -Wextra
+LDFLAGS :=
+SRCDIR  := src
+OBJDIR  := build
+BIN     := $(OBJDIR)/app
+
+SOURCES := $(wildcard $(SRCDIR)/*.c)
+OBJECTS := $(SOURCES:$(SRCDIR)/%.c=$(OBJDIR)/%.o)
+
+# Conditional based on environment
+ifeq ($(DEBUG),1)
+  CFLAGS += -g -O0 -DDEBUG
+else
+  CFLAGS += -DNDEBUG
+endif
+
+UNAME := $(shell uname -s)
+ifeq ($(UNAME),Darwin)
+  LDFLAGS += -framework CoreFoundation
+endif
+
+.PHONY: all clean test install
+
+all: $(BIN)
+
+$(BIN): $(OBJECTS) | $(OBJDIR)
+	$(CC) $(LDFLAGS) -o $@ $^
+
+$(OBJDIR)/%.o: $(SRCDIR)/%.c | $(OBJDIR)
+	$(CC) $(CFLAGS) -c $< -o $@
+
+$(OBJDIR):
+	mkdir -p $@
+
+test: $(BIN)
+	./$(BIN) --self-test
+
+install: $(BIN)
+	install -m 0755 $(BIN) $(DESTDIR)/usr/local/bin/
+
+clean:
+	rm -rf $(OBJDIR)
+
+# Pattern rule
+%.tar.gz: %
+	tar -czf $@ $<
+
+# Function definition
+define greet
+	@echo "Hello, $(1)!"
+endef
+
+hello:
+	$(call greet,world)


### PR DESCRIPTION
## Summary

- Adds the [tree-sitter-grammars/tree-sitter-make](https://github.com/tree-sitter-grammars/tree-sitter-make) grammar (MIT, pinned to `70613f3`) as `lang-makefile` in `group-maple`, alongside cmake/meson/ninja/dockerfile.
- Uses `c_symbol: make` in `arborium.yaml` so the generated bindings link the upstream `tree_sitter_make` C symbol while exposing the language as `makefile` in arborium (same pattern as `rust`/`rust_orchard`).
- Ships upstream's `highlights.scm` and `injections.scm` queries unchanged; `injections.scm` injects `bash` into recipe shell commands.
- Adds a hand-written ~50-line sample exercising variables, conditionals, pattern rules, automatic variables (\`$@\`, \`$<\`, \`$^\`), \`$(shell ...)\`, \`.PHONY\`, and \`define\`/\`endef\`.
- Regenerates \`.github/workflows/ci.yml\` to include \`makefile\` in the maple plugin build job.
- Adds the grammar's MIT attribution row to \`LICENSES.md\`.

## Test plan

- [x] \`cargo xtask gen makefile\` regenerates parser + crate cleanly
- [x] \`cargo xtask lint\` exits 0 with no makefile-specific findings
- [x] \`cargo xtask grammar-test makefile\` — both \`test_grammar\` and \`test_corpus\` pass
- [x] \`tree-sitter parse\` of the sample produces no ERROR or MISSING nodes
- [x] CLI smoke test: \`arborium --features lang-makefile -- example.mk\` produces fully colorized ANSI output (variables, conditionals, builtins, automatic vars, comments, recipes)
- [ ] CI plugin build (\`build-plugins-maple\`) green