### PR TITLE
Add Cirq and Cirq Control tree-sitter grammars

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -427,7 +427,7 @@ jobs:
           path: dist/plugins
           retention-days: "7"
   build-plugins-hazel: 
-    name: "Plugins (hazel): awk, bash, batch, fish, lua, perl, php, powershell, python, ruby, zsh"
+    name: "Plugins (hazel): awk, bash, batch, cirq-control, fish, lua, perl, php, powershell, python, ruby, zsh"
     runs-on: depot-ubuntu-24.04-32
     container: "ghcr.io/bearcove/arborium-plugin-builder:latest"
     needs: 
@@ -445,10 +445,10 @@ jobs:
           set -e
           tar -xf generate-output.tar && rm generate-output.tar
         shell: bash
-      - name: Build awk, bash, batch, fish, lua, perl, php, powershell, python, ruby, zsh
+      - name: Build awk, bash, batch, cirq-control, fish, lua, perl, php, powershell, python, ruby, zsh
         run: |-
           set -e
-          ./xtask/target/release/xtask build awk bash batch fish lua perl php powershell python ruby zsh -o dist/plugins
+          ./xtask/target/release/xtask build awk bash batch cirq-control fish lua perl php powershell python ruby zsh -o dist/plugins
         shell: bash
       - name: Upload plugins artifact
         uses: actions/upload-artifact@v5
@@ -487,7 +487,7 @@ jobs:
           path: dist/plugins
           retention-days: "7"
   build-plugins-moss: 
-    name: "Plugins (moss): ada, glsl, hlsl, julia, matlab, prolog, r, sparql, tlaplus, verilog, vhdl"
+    name: "Plugins (moss): ada, cirq, glsl, hlsl, julia, matlab, prolog, r, sparql, tlaplus, verilog, vhdl"
     runs-on: depot-ubuntu-24.04-32
     container: "ghcr.io/bearcove/arborium-plugin-builder:latest"
     needs: 
@@ -505,10 +505,10 @@ jobs:
           set -e
           tar -xf generate-output.tar && rm generate-output.tar
         shell: bash
-      - name: Build ada, glsl, hlsl, julia, matlab, prolog, r, sparql, tlaplus, verilog, vhdl
+      - name: Build ada, cirq, glsl, hlsl, julia, matlab, prolog, r, sparql, tlaplus, verilog, vhdl
         run: |-
           set -e
-          ./xtask/target/release/xtask build ada glsl hlsl julia matlab prolog r sparql tlaplus verilog vhdl -o dist/plugins
+          ./xtask/target/release/xtask build ada cirq glsl hlsl julia matlab prolog r sparql tlaplus verilog vhdl -o dist/plugins
         shell: bash
       - name: Upload plugins artifact
         uses: actions/upload-artifact@v5

--- a/langs/group-hazel/cirq-control/def/arborium.yaml
+++ b/langs/group-hazel/cirq-control/def/arborium.yaml
@@ -1,0 +1,26 @@
+repo: https://github.com/cramt/thevenin
+commit: 1de9537c7d0d599f0f1f056deb73aab8a62201e4
+license: BSD-3-Clause
+
+grammars:
+  - id: cirq-control
+    name: Cirq Control
+    tag: code
+    tier: 5
+    has_scanner: false
+    generate_plugin: true
+    c_symbol: control
+    icon: mdi:console-line
+    aliases:
+      - control
+
+    inventor: Alexandra Østermark
+    year: 2025
+    description: "The ngspice .control scripting language as implemented by the Thevenin simulator — a line-oriented language with let/print/run/measure statements, if/while/repeat/foreach blocks, and a shared vector-expression sublanguage."
+    link: https://github.com/cramt/thevenin
+    trivia: "Control scripts drive simulation runs in Thevenin's `.control` blocks. The grammar models the editor-facing surface syntax; the interpreter does its own string-based parse for execution, with corpus tests keeping the two in sync."
+
+    samples:
+      - path: samples/analysis.control
+        description: A control script that runs op/transient analyses, measures a derived vector, and uses foreach/repeat/while/if blocks.
+        license: BSD-3-Clause

--- a/langs/group-hazel/cirq-control/def/grammar/grammar.js
+++ b/langs/group-hazel/cirq-control/def/grammar/grammar.js
@@ -1,0 +1,460 @@
+/// <reference types="tree-sitter-cli/dsl" />
+// @ts-check
+
+/**
+ * Tree-sitter grammar for the ngspice .control scripting language.
+ *
+ * The control language is line-oriented: one statement per line, with
+ * block statements (if/while/repeat/foreach) terminating on a bare
+ * `end` line. Comments start with `*` at the first non-whitespace
+ * position of a line; an inline `$ ` (dollar-space) also starts a
+ * comment that runs to end-of-line.
+ *
+ * Expressions inside `let`, `if`, `while`, `print`, etc. share a single
+ * vecexpr grammar — vector arithmetic, comparison, function calls,
+ * `v(node)` / `i(elem)` / `@dev[param]` references, and SPICE-style
+ * numeric literals.
+ *
+ * This grammar is the CST surface used for editor highlighting and
+ * static analysis. The thevenin-control interpreter does its own
+ * (string-based) parse for execution — keeping the two in sync is the
+ * responsibility of corpus tests, not the type system.
+ */
+
+module.exports = grammar({
+  name: "control",
+
+  extras: ($) => [/[ \t\r]/, $.line_comment, $.inline_comment, $.line_continuation],
+
+  word: ($) => $.identifier,
+
+
+  rules: {
+    source_file: ($) => repeat(choice($._statement, $._nl)),
+
+    // Statements are line-terminated. Block statements consume their
+    // bodies (which are themselves newline-separated statements) and
+    // close with a bare `end` line.
+    _statement: ($) =>
+      choice(
+        $.let_stmt,
+        $.echo_stmt,
+        $.if_stmt,
+        $.foreach_stmt,
+        $.while_stmt,
+        $.repeat_stmt,
+        $.save_stmt,
+        $.quit_stmt,
+        $.set_stmt,
+        $.setplot_stmt,
+        $.define_stmt,
+        $.compose_stmt,
+        $.alter_stmt,
+        $.strcmp_stmt,
+        $.print_stmt,
+        $.write_stmt,
+        $.run_analysis,
+        $.eprint_stmt,
+        $.stop_when_stmt,
+        $.resume_stmt,
+        $.source_stmt,
+        $.measure_stmt,
+        $.unknown_stmt
+      ),
+
+    // ── Block-terminating statements ────────────────────────────
+
+    let_stmt: ($) =>
+      seq(
+        "let",
+        field("name", choice($.indexed_target, $.identifier)),
+        "=",
+        field("value", $._expression),
+        $._nl
+      ),
+
+    indexed_target: ($) =>
+      seq(field("name", $.identifier), "[", field("index", $._expression), "]"),
+
+    echo_stmt: ($) =>
+      seq("echo", repeat($._echo_fragment), $._nl),
+
+    _echo_fragment: ($) =>
+      choice(
+        $.vec_scalar_ref,
+        $.var_ref,
+        $.string_literal,
+        $.echo_word
+      ),
+
+    var_ref: ($) => seq("$", field("name", $._var_name)),
+    vec_scalar_ref: ($) => seq("$&", field("name", $._var_name)),
+    _var_name: ($) => alias($.identifier, $.var_name),
+
+    // Anything else on the echo line that isn't whitespace, a var ref,
+    // a string, or a newline is treated as a literal word. The negative
+    // precedence keeps this from competing with proper tokens.
+    echo_word: (_$) => token(prec(-2, /[^\s$"\n][^\s\n]*/)),
+
+    if_stmt: ($) =>
+      seq(
+        "if",
+        field("condition", $._expression),
+        $._nl,
+        field("body", $.block),
+        optional(
+          seq(
+            "else",
+            $._nl,
+            field("else_body", $.block)
+          )
+        ),
+        "end",
+        $._nl
+      ),
+
+    foreach_stmt: ($) =>
+      seq(
+        "foreach",
+        field("var", $.identifier),
+        field("values", repeat1($._foreach_value)),
+        $._nl,
+        field("body", $.block),
+        "end",
+        $._nl
+      ),
+
+    _foreach_value: ($) => choice($.number_literal, $.identifier, $.string_literal),
+
+    while_stmt: ($) =>
+      seq(
+        "while",
+        field("condition", $._expression),
+        $._nl,
+        field("body", $.block),
+        "end",
+        $._nl
+      ),
+
+    repeat_stmt: ($) =>
+      seq(
+        "repeat",
+        field("count", $._expression),
+        $._nl,
+        field("body", $.block),
+        "end",
+        $._nl
+      ),
+
+    // A block is just a run of statements (possibly empty). Newlines
+    // between statements are folded by the `_nl` rule.
+    block: ($) => repeat1(choice($._statement, $._nl)),
+
+    // ── Single-line statements ──────────────────────────────────
+
+    save_stmt: ($) =>
+      seq("save", repeat($._save_spec), $._nl),
+
+    _save_spec: ($) => choice($.vector_ref, $.identifier, $.device_param),
+
+    quit_stmt: ($) =>
+      seq("quit", optional(field("code", $.number_literal)), $._nl),
+
+    set_stmt: ($) =>
+      seq("set", repeat1($._set_pair), $._nl),
+
+    _set_pair: ($) =>
+      choice(
+        seq(field("name", $.identifier), "=", field("value", $._set_value)),
+        field("name", $.identifier)
+      ),
+
+    _set_value: ($) =>
+      choice($.string_literal, $.number_literal, $.identifier),
+
+    setplot_stmt: ($) =>
+      seq("setplot", field("plot", $.identifier), $._nl),
+
+    define_stmt: ($) =>
+      seq(
+        "define",
+        field("name", $.identifier),
+        "(",
+        optional(field("args", $.arg_list)),
+        ")",
+        field("body", $._expression),
+        $._nl
+      ),
+
+    arg_list: ($) =>
+      seq($.identifier, repeat(seq(",", $.identifier)), optional(",")),
+
+    compose_stmt: ($) =>
+      seq(
+        "compose",
+        field("name", $.identifier),
+        optional("values"),
+        repeat1($._expression),
+        $._nl
+      ),
+
+    alter_stmt: ($) =>
+      seq(
+        "alter",
+        field("target", choice($.device_param, $.identifier)),
+        "=",
+        field("value", choice($.alter_vector, $._expression)),
+        $._nl
+      ),
+
+    alter_vector: ($) =>
+      seq("[", repeat($.number_literal), "]"),
+
+    strcmp_stmt: ($) =>
+      seq(
+        "strcmp",
+        field("result", $.identifier),
+        field("a", $._expression),
+        field("b", $._expression),
+        $._nl
+      ),
+
+    print_stmt: ($) =>
+      seq(
+        "print",
+        repeat1($._print_item),
+        optional(seq(">", field("file", $._expression))),
+        $._nl
+      ),
+
+    _print_item: ($) =>
+      choice(
+        alias("col", $.print_mode),
+        alias("line", $.print_mode),
+        $._expression
+      ),
+
+    write_stmt: ($) =>
+      seq("write", repeat($._expression), $._nl),
+
+    run_analysis: ($) =>
+      seq(
+        field(
+          "kind",
+          choice("op", "dc", "ac", "tran", "sens", "noise", "pz", "tf", "run")
+        ),
+        repeat($._analysis_arg),
+        $._nl
+      ),
+
+    _analysis_arg: ($) =>
+      choice($.number_literal, $.identifier, $.string_literal),
+
+    eprint_stmt: ($) =>
+      seq(choice("eprint", "eprvcd"), repeat($._expression), $._nl),
+
+    stop_when_stmt: ($) =>
+      seq(
+        "stop",
+        "when",
+        field("var", $.identifier),
+        choice("=", "<", ">", "<=", ">="),
+        field("value", $._expression),
+        $._nl
+      ),
+
+    resume_stmt: ($) => seq("resume", $._nl),
+
+    source_stmt: ($) =>
+      seq("source", field("path", $._expression), $._nl),
+
+    measure_stmt: ($) =>
+      seq(
+        choice("measure", "meas"),
+        field("kind", $.identifier),
+        field("name", $.identifier),
+        repeat($._expression),
+        $._nl
+      ),
+
+    // Catch-all so unknown commands don't break the whole script. The
+    // executor treats unknown statements as no-ops, so mirroring that
+    // here keeps the CST useful for partial files.
+    unknown_stmt: ($) =>
+      seq(
+        field("command", $.identifier),
+        repeat($._unknown_arg),
+        $._nl
+      ),
+
+    _unknown_arg: ($) =>
+      choice($.identifier, $.number_literal, $.string_literal, $.vector_ref, $.device_param),
+
+    // ── Expressions ─────────────────────────────────────────────
+
+    _expression: ($) =>
+      choice(
+        $.binary_expression,
+        $.unary_expression,
+        $.call_expression,
+        $.vector_ref,
+        $.device_param,
+        $.indexed_expression,
+        $.range_expression,
+        $.paren_expression,
+        $.number_literal,
+        $.string_literal,
+        $.var_ref,
+        $.vec_scalar_ref,
+        $.identifier
+      ),
+
+    binary_expression: ($) =>
+      choice(
+        prec.right(
+          7,
+          seq(
+            field("left", $._expression),
+            field("operator", choice("^", "**")),
+            field("right", $._expression)
+          )
+        ),
+        ...[
+          [["or"], 1],
+          [["and"], 2],
+          [["=", "<>"], 3],
+          [["<", ">", "<=", ">="], 4],
+          [["+", "-", ".+", ".-"], 5],
+          [["*", "/", ".*", "./"], 6],
+        ].flatMap(([ops, p]) =>
+          /** @type {readonly string[]} */ (ops).map((op) =>
+            prec.left(
+              /** @type {number} */ (p),
+              seq(
+                field("left", $._expression),
+                field("operator", op),
+                field("right", $._expression)
+              )
+            )
+          )
+        )
+      ),
+
+    unary_expression: ($) =>
+      prec(
+        8,
+        seq(
+          field("operator", choice("-", "!", "not")),
+          field("operand", $._expression)
+        )
+      ),
+
+    call_expression: ($) =>
+      prec(
+        9,
+        seq(
+          field("function", $.identifier),
+          "(",
+          optional(
+            seq($._expression, repeat(seq(",", $._expression)), optional(","))
+          ),
+          ")"
+        )
+      ),
+
+    // `v(node)`, `v(n1, n2)`, `i(element)` — special-cased so highlights
+    // can colour them as references rather than function calls.
+    vector_ref: ($) =>
+      prec(
+        10,
+        seq(
+          field("kind", choice("v", "i", "vm", "vp", "vr", "vi", "vdb", "im", "ip", "ir", "ii", "idb")),
+          "(",
+          field("node", $.identifier),
+          optional(seq(",", field("node2", $.identifier))),
+          ")"
+        )
+      ),
+
+    // `@device[param]` — device-parameter query. The grammar treats it
+    // atomically since the lexer-level interaction between brackets in
+    // the spec and brackets used for postfix indexing is delicate; the
+    // executor splits the two apart at evaluation time.
+    device_param: (_$) =>
+      token(seq("@", /[A-Za-z_][A-Za-z0-9_]*/, "[", /[A-Za-z_][A-Za-z0-9_]*/, "]")),
+
+    indexed_expression: ($) =>
+      prec.left(
+        10,
+        seq(field("value", $._expression), "[", field("index", $._expression), "]")
+      ),
+
+    range_expression: ($) =>
+      prec.left(
+        10,
+        seq(
+          field("value", $._expression),
+          "[",
+          field("start", $._expression),
+          ":",
+          field("end", $._expression),
+          "]"
+        )
+      ),
+
+    paren_expression: ($) =>
+      seq(
+        "(",
+        $._expression,
+        repeat(seq(",", $._expression)),
+        optional(","),
+        ")"
+      ),
+
+    // ── Literals ────────────────────────────────────────────────
+
+    number_literal: (_$) =>
+      token(
+        seq(
+          choice(
+            seq(/[0-9][0-9_]*/, optional(seq(".", /[0-9_]*/))),
+            seq(".", /[0-9][0-9_]*/)
+          ),
+          optional(seq(choice("e", "E"), optional(choice("+", "-")), /[0-9][0-9_]*/)),
+          // Optional SPICE SI suffix + optional unit
+          optional(choice("T", "G", "Meg", "K", "k", "M", "m", "u", "U", "n", "N", "p", "P", "f", "F", "a", "A")),
+          optional(choice("V", "v", "A", "a", "W", "w", "S", "s", "Hz", "hz", "Ohm", "ohm", "F", "f", "H", "h"))
+        )
+      ),
+
+    string_literal: (_$) =>
+      token(seq('"', repeat(choice(/[^"\\\n]/, seq("\\", /./))), '"')),
+
+    // ── Identifiers, comments, newlines ─────────────────────────
+
+    identifier: (_$) => /[A-Za-z_][A-Za-z0-9_.#]*/,
+
+    // Statement separator — one or more newlines, possibly with
+    // a leading `;` (ngspice treats `;` like a newline in many contexts).
+    _nl: (_$) => token(prec(-1, /[;\n]+/)),
+
+    // Backslash-newline continues the logical line (carried over from
+    // some ngspice host shells).
+    line_continuation: (_$) => token(seq("\\", "\n")),
+
+    // Full-line comment: `*` as the first non-whitespace char of the
+    // line consumes the rest of the line. Modelled with a `^` anchor
+    // approximation: `*` must be followed by either non-newline content
+    // or be alone. Tree-sitter does not honour `^`, so we accept `*`
+    // anywhere and rely on the surrounding grammar (no `*` token is
+    // valid mid-statement at the start of an expression) to keep this
+    // unambiguous.
+    line_comment: (_$) =>
+      token(prec(-1, seq("*", /[^\n]*/))),
+
+    // Inline `$` followed by whitespace or end-of-line starts a comment.
+    // Models the ngspice convention without breaking `$var` references.
+    inline_comment: (_$) =>
+      token(prec(-1, seq("$", /[ \t][^\n]*/))),
+  },
+});

--- a/langs/group-hazel/cirq-control/def/queries/highlights.scm
+++ b/langs/group-hazel/cirq-control/def/queries/highlights.scm
@@ -1,0 +1,143 @@
+; ngspice .control tree-sitter highlights
+; =========================================
+
+; ── Keywords ────────────────────────────────────────────────
+
+[
+  "let"
+  "echo"
+  "if"
+  "else"
+  "end"
+  "foreach"
+  "while"
+  "repeat"
+  "save"
+  "quit"
+  "set"
+  "setplot"
+  "define"
+  "compose"
+  "alter"
+  "strcmp"
+  "print"
+  "write"
+  "eprint"
+  "eprvcd"
+  "stop"
+  "when"
+  "resume"
+  "source"
+  "measure"
+  "meas"
+  "values"
+] @keyword
+
+(run_analysis
+  kind: _ @keyword)
+
+; ── Comments ────────────────────────────────────────────────
+
+(line_comment) @comment
+(inline_comment) @comment
+
+; ── Literals ────────────────────────────────────────────────
+
+(number_literal) @number
+(string_literal) @string
+
+; ── Print mode hints ────────────────────────────────────────
+
+(print_mode) @keyword
+
+; ── Variable references ─────────────────────────────────────
+
+(var_ref
+  "$" @punctuation.special
+  name: (var_name) @variable)
+
+(vec_scalar_ref
+  "$&" @punctuation.special
+  name: (var_name) @variable)
+
+; ── Vector / device references ──────────────────────────────
+
+(vector_ref
+  kind: _ @function.builtin)
+
+(vector_ref
+  node: (identifier) @variable)
+
+(vector_ref
+  node2: (identifier) @variable)
+
+(device_param) @attribute
+
+; ── Declarations ────────────────────────────────────────────
+
+(let_stmt
+  name: (identifier) @variable)
+
+(let_stmt
+  name: (indexed_target
+    name: (identifier) @variable))
+
+(setplot_stmt
+  plot: (identifier) @namespace)
+
+(define_stmt
+  name: (identifier) @function)
+
+(define_stmt
+  args: (arg_list
+    (identifier) @variable.parameter))
+
+(compose_stmt
+  name: (identifier) @variable)
+
+(strcmp_stmt
+  result: (identifier) @variable)
+
+(measure_stmt
+  name: (identifier) @variable)
+
+(measure_stmt
+  kind: (identifier) @type)
+
+(stop_when_stmt
+  var: (identifier) @variable)
+
+(foreach_stmt
+  var: (identifier) @variable)
+
+; ── Operators / punctuation ─────────────────────────────────
+
+(binary_expression
+  operator: _ @operator)
+
+(unary_expression
+  operator: _ @operator)
+
+"=" @operator
+">" @operator
+"<" @operator
+">=" @operator
+"<=" @operator
+"<>" @operator
+
+"(" @punctuation.bracket
+")" @punctuation.bracket
+"[" @punctuation.bracket
+"]" @punctuation.bracket
+
+"," @punctuation.delimiter
+":" @punctuation.delimiter
+
+; ── Function calls (fallback after the vector_ref special-case) ──
+
+(call_expression
+  function: (identifier) @function.builtin)
+
+; ── Identifiers (fallback) ──────────────────────────────────
+
+(identifier) @variable

--- a/langs/group-hazel/cirq-control/def/samples/analysis.control
+++ b/langs/group-hazel/cirq-control/def/samples/analysis.control
@@ -1,0 +1,38 @@
+* ngspice .control script: sweep the supply, measure gain, and report.
+* Line comments start with `*`; an inline `$ ` also begins a comment.
+
+set noaskquit          $ don't prompt on quit
+
+let vstart = 1.0
+let vstop  = 5.0
+
+* Run a DC operating point, then a transient analysis.
+op
+tran 1n 100n
+
+* Compute a derived vector and a scalar measurement.
+let gain = v(out) / v(in)
+measure tran vpp PP v(out)
+
+print col gain v(out) > results.txt
+
+* Block statements terminate on a bare `end` line.
+foreach corner ff tt ss
+  echo "corner =" $corner "gain =" $&gain
+end
+
+repeat 3
+  let vstart = vstart + 0.5
+end
+
+while vstart < vstop
+  let vstart = vstart + 1.0
+end
+
+if gain > 10
+  echo "high gain"
+else
+  echo "low gain"
+end
+
+quit 0

--- a/langs/group-moss/cirq/def/arborium.yaml
+++ b/langs/group-moss/cirq/def/arborium.yaml
@@ -1,0 +1,46 @@
+repo: https://github.com/cramt/thevenin
+commit: 1de9537c7d0d599f0f1f056deb73aab8a62201e4
+license: BSD-3-Clause
+
+grammars:
+  - id: cirq
+    name: Cirq
+    tag: code
+    tier: 5
+    has_scanner: true
+    generate_plugin: true
+    icon: mdi:chip
+    aliases:
+      - cirq
+
+    inventor: Alexandra Østermark
+    year: 2025
+    description: "Cirq is a circuit description language for the Thevenin SPICE simulator, with circuits, reusable modules, parameters, device models, and analysis declarations."
+    link: https://github.com/cramt/thevenin
+    trivia: "Cirq is the native source language of Thevenin, a from-scratch Rust rewrite of ngspice. SPICE netlists are imported into Cirq's IR, which is the canonical input to the simulator's analyses. Its `code \"lang\" { ... }` blocks embed other languages, parsed by a hand-written brace-counting scanner."
+
+    samples:
+      - path: samples/voltage_divider.cirq
+        description: The "hello world" of circuit simulation — a voltage divider with a DC operating-point analysis.
+        link: https://github.com/cramt/thevenin/blob/main/examples/cirq/voltage_divider.cirq
+        license: BSD-3-Clause
+
+      - path: samples/fourier.cirq
+        description: Native Fourier / FFT post-processing over a transient analysis.
+        link: https://github.com/cramt/thevenin/blob/main/examples/cirq/fourier.cirq
+        license: BSD-3-Clause
+
+      - path: samples/cmos_inverter.cirq
+        description: CMOS inverter with NMOS/PMOS model declarations, a PULSE source, and transient analysis.
+        link: https://github.com/cramt/thevenin/blob/main/examples/cirq/cmos_inverter.cirq
+        license: BSD-3-Clause
+
+      - path: samples/hierarchical.cirq
+        description: Hierarchical design with reusable modules and instance wiring.
+        link: https://github.com/cramt/thevenin/blob/main/examples/cirq/hierarchical.cirq
+        license: BSD-3-Clause
+
+      - path: samples/conditional.cirq
+        description: Compile-time if/elseif/else for conditional parameters, elements, and analyses.
+        link: https://github.com/cramt/thevenin/blob/main/examples/cirq/conditional.cirq
+        license: BSD-3-Clause

--- a/langs/group-moss/cirq/def/grammar/grammar.js
+++ b/langs/group-moss/cirq/def/grammar/grammar.js
@@ -1,0 +1,585 @@
+/// <reference types="tree-sitter-cli/dsl" />
+// @ts-check
+
+/**
+ * Tree-sitter grammar for the Cirq circuit description language.
+ *
+ * This grammar defines the concrete syntax tree (CST) for Cirq.
+ * The CST is then lowered to an AST in the cirq-ast Rust crate.
+ */
+
+module.exports = grammar({
+  name: "cirq",
+
+  extras: ($) => [/\s/, /;/, $.line_comment, $.block_comment],
+
+  word: ($) => $.identifier,
+
+  // Externally-tokenized symbols. The body of `code "lang" { ... }` is
+  // consumed by a hand-written scanner (src/scanner.c) that counts nested
+  // braces and skips over string literals, so that braces appearing inside
+  // the embedded language don't terminate the block prematurely.
+  externals: ($) => [$.code_body],
+
+  rules: {
+    source_file: ($) => repeat($._top_level),
+
+    _top_level: ($) =>
+      choice($.circuit_decl, $.module_decl, $.import_decl, $.export_decl, $.model_decl, $.func_decl),
+
+    // ── Circuit ──────────────────────────────────────────────────────
+
+    circuit_decl: ($) =>
+      seq(
+        repeat($.attribute),
+        "circuit",
+        field("name", $.identifier),
+        "{",
+        repeat($._circuit_item),
+        "}"
+      ),
+
+    _circuit_item: ($) =>
+      choice(
+        $.param_decl,
+        $.let_decl,
+        $.element_inst,
+        $.module_inst,
+        $.module_decl,
+        $.model_decl,
+        $.analysis_decl,
+        $.global_decl,
+        $.options_decl,
+        $.temp_decl,
+        $.save_decl,
+        $.func_decl,
+        $.ic_decl,
+        $.coupled_line_decl,
+        $.code_decl,
+        $.measure_decl,
+        $.conditional_decl
+      ),
+
+    // ── Compile-time conditional ─────────────────────────────────────
+    //
+    // `if <cond> { items } elseif <cond> { items } else { items }`.
+    // Resolved at lowering time: the condition is a constant expression over
+    // params/literals, and only the taken branch's items reach the IR. The
+    // body holds any circuit item (params, elements, models, analyses, or a
+    // nested conditional), so it works at circuit and module scope alike.
+    conditional_decl: ($) =>
+      seq(
+        "if",
+        field("condition", $._expression),
+        field("then", $.conditional_block),
+        repeat($.elseif_clause),
+        optional($.else_clause)
+      ),
+
+    elseif_clause: ($) =>
+      seq("elseif", field("condition", $._expression), field("body", $.conditional_block)),
+
+    else_clause: ($) => seq("else", field("body", $.conditional_block)),
+
+    conditional_block: ($) => seq("{", repeat($._circuit_item), "}"),
+
+    // ── Module ───────────────────────────────────────────────────────
+
+    module_decl: ($) =>
+      seq(
+        repeat($.attribute),
+        "module",
+        field("name", $.identifier),
+        optional(seq(":", field("base", $.identifier))),
+        "{",
+        repeat(choice($.port_decl, $._circuit_item)),
+        "}"
+      ),
+
+    port_decl: ($) =>
+      seq(
+        repeat($.attribute),
+        "port",
+        field("name", $.identifier),
+        ":",
+        field("direction", $.port_direction)
+      ),
+
+    port_direction: (_$) => choice("in", "out", "inout"),
+
+    // ── Elements ─────────────────────────────────────────────────────
+
+    element_inst: ($) =>
+      seq(
+        repeat($.attribute),
+        field("name", $.identifier),
+        ":",
+        field("type", $.identifier),
+        "(",
+        optional($.argument_list),
+        ")"
+      ),
+
+    module_inst: ($) =>
+      seq(
+        repeat($.attribute),
+        field("name", $.identifier),
+        ":",
+        field("module", $.qualified_name),
+        "(",
+        optional($.argument_list),
+        ")"
+      ),
+
+    argument_list: ($) => seq($.argument, repeat(seq(",", $.argument)), optional(",")),
+
+    argument: ($) =>
+      choice(
+        $.named_argument,
+        $.connection,
+        $.named_connection,
+        $._expression
+      ),
+
+    named_argument: ($) =>
+      seq(field("name", $.identifier), ":", field("value", $._expression)),
+
+    connection: ($) =>
+      seq(field("from", $._net_ref), "->", field("to", $._net_ref)),
+
+    named_connection: ($) =>
+      seq(
+        field("name", $.identifier),
+        ":",
+        field("from", $._net_ref),
+        "->",
+        field("to", $._net_ref)
+      ),
+
+    _net_ref: ($) => choice($.identifier, $.gnd),
+
+    // ── Parameters ───────────────────────────────────────────────────
+
+    param_decl: ($) =>
+      seq(
+        repeat($.attribute),
+        "param",
+        field("name", $.identifier),
+        optional(seq(":", field("type", $.identifier))),
+        optional(seq("=", field("value", $._expression)))
+      ),
+
+    let_decl: ($) =>
+      seq(
+        repeat($.attribute),
+        "let",
+        field("name", $.identifier),
+        "=",
+        field("value", $._expression)
+      ),
+
+    global_decl: ($) => seq("global", field("name", $.identifier)),
+
+    // ── User-defined functions ──────────────────────────────────────
+
+    func_decl: ($) =>
+      seq(
+        field("name", $.identifier),
+        "(",
+        optional($.func_params),
+        ")",
+        "=",
+        field("body", $._expression)
+      ),
+
+    func_params: ($) =>
+      seq($.identifier, repeat(seq(",", $.identifier)), optional(",")),
+
+    // ── Initial conditions ──────────────────────────────────────────
+
+    ic_decl: ($) =>
+      seq(
+        "ic",
+        "{",
+        repeat($.ic_entry),
+        "}"
+      ),
+
+    ic_entry: ($) =>
+      seq(
+        "v",
+        "(",
+        field("node", $.identifier),
+        ")",
+        "=",
+        field("value", $._expression)
+      ),
+
+    // ── Coupled transmission lines ─────────────────────────────────
+
+    coupled_line_decl: ($) =>
+      seq(
+        "coupled_line",
+        field("name", $.identifier),
+        "{",
+        repeat($.coupled_line_field),
+        "}"
+      ),
+
+    coupled_line_field: ($) =>
+      seq(
+        field("key", $.identifier),
+        ":",
+        field("value", $._expression)
+      ),
+
+    // ── Code block (verbatim embedded language) ──────────────────────
+
+    code_decl: ($) =>
+      seq("code", field("language", $.string_literal), "{", optional(field("body", $.code_body)), "}"),
+
+    // Raw content between { and } for a `code "lang" { ... }` block.
+    // The real token is produced by the external scanner; this rule
+    // exists only so the generator knows the symbol and so error
+    // recovery has something to fall back on. The external scanner
+    // tracks brace depth and skips over string literals so embedded
+    // braces (e.g. JS object literals) don't terminate the block.
+    code_body: (_$) => token(prec(-1, /[^}]+/)),
+
+    // ── Measure block ───────────────────────────────────────────────
+
+    // Two forms:
+    //   1. Expression form (native, preferred):
+    //        measure tran vout_max = max(v(out), from: 10n, to: 50n)
+    //      The name is an identifier and the body is a single expression.
+    //   2. Block form (legacy / escape hatch):
+    //        measure tran "vout_max" { spec: "MAX v(out)" }
+    //      The name is a string literal and the body wraps a verbatim SPICE
+    //      `.meas` clause string in a `spec:` field.
+    measure_decl: ($) =>
+      choice(
+        seq(
+          "measure",
+          field("analysis_kind", $.identifier),
+          field("name", $.identifier),
+          "=",
+          field("value", $._expression)
+        ),
+        seq(
+          "measure",
+          field("analysis_kind", $.identifier),
+          field("name", $.string_literal),
+          "{",
+          repeat($.measure_field),
+          "}"
+        )
+      ),
+
+    measure_field: ($) =>
+      seq(
+        field("key", $.identifier),
+        ":",
+        field("value", $.string_literal)
+      ),
+
+    // ── Options and Temperature ─────────────────────────────────────
+
+    options_decl: ($) =>
+      seq(
+        "options",
+        "{",
+        repeat($.options_setting),
+        "}"
+      ),
+
+    options_setting: ($) =>
+      seq(field("name", $.identifier), ":", field("value", $._expression)),
+
+    temp_decl: ($) =>
+      seq("temp", field("value", $._expression)),
+
+    save_decl: ($) =>
+      seq(
+        "save",
+        "{",
+        repeat($.save_target),
+        "}"
+      ),
+
+    save_target: ($) =>
+      choice(
+        // v(node) or v(node1, node2) — voltage probe
+        seq(
+          field("type", "v"),
+          "(",
+          field("node", $.identifier),
+          optional(seq(",", field("node2", $.identifier))),
+          ")"
+        ),
+        // i(element) — current probe
+        seq(
+          field("type", "i"),
+          "(",
+          field("element", $.identifier),
+          ")"
+        ),
+        // Bare identifier — raw save target
+        field("name", $.identifier)
+      ),
+
+    // ── Models ──────────────────────────────────────────────────────
+
+    model_decl: ($) =>
+      seq(
+        repeat($.attribute),
+        "model",
+        field("name", $.identifier),
+        ":",
+        field("device_type", $.identifier),
+        "{",
+        repeat($.model_param),
+        "}"
+      ),
+
+    model_param: ($) =>
+      seq(field("name", $.identifier), "=", field("value", $._expression)),
+
+    // ── Analysis ─────────────────────────────────────────────────────
+
+    analysis_decl: ($) =>
+      seq(
+        "analysis",
+        field("kind", $.identifier),
+        "{",
+        repeat($._analysis_item),
+        "}"
+      ),
+
+    _analysis_item: ($) => choice($.analysis_setting, $.sweep_spec),
+
+    analysis_setting: ($) =>
+      seq(field("name", $.identifier), ":", field("value", $._expression)),
+
+    sweep_spec: ($) =>
+      seq(
+        "sweep",
+        field("source", $.identifier),
+        ":",
+        field("start", $._expression),
+        "..",
+        field("stop", $._expression),
+        "step",
+        field("step", $._expression)
+      ),
+
+    // ── Import ───────────────────────────────────────────────────────
+
+    import_decl: ($) =>
+      choice(
+        // Named import: import { name1, name2 } from "path"
+        seq(
+          "import",
+          "{",
+          field("names", $.import_names),
+          "}",
+          "from",
+          field("path", $.string_literal)
+        ),
+        // Plain or aliased import: import "path" [as alias]
+        seq(
+          "import",
+          field("path", $.string_literal),
+          optional(seq("as", field("alias", $.identifier)))
+        )
+      ),
+
+    import_names: ($) =>
+      seq($.identifier, repeat(seq(",", $.identifier)), optional(",")),
+
+    // ── Export ───────────────────────────────────────────────────────
+
+    export_decl: ($) =>
+      seq(
+        "export",
+        field("name", $.identifier),
+        "{",
+        repeat($._export_item),
+        "}"
+      ),
+
+    _export_item: ($) =>
+      choice($.model_decl, $.module_decl, $.func_decl, $.param_decl),
+
+    // ── Attributes ───────────────────────────────────────────────────
+
+    attribute: ($) =>
+      seq(
+        "@",
+        field("name", $.identifier),
+        optional(seq("(", optional($.argument_list), ")"))
+      ),
+
+    // ── Expressions ──────────────────────────────────────────────────
+
+    _expression: ($) =>
+      choice(
+        $.ternary_expression,
+        $.binary_expression,
+        $.unary_expression,
+        $.call_expression,
+        $.paren_expression,
+        $.number_literal,
+        $.string_literal,
+        $.boolean_literal,
+        $.identifier,
+        $.qualified_name,
+        $.list_literal,
+        $.block_literal,
+        $.gnd
+      ),
+
+    // Ternary `cond ? then : else`. Right-associative and lower precedence
+    // than `||` / `&&` so `a || b ? x : y` parses as `(a || b) ? x : y`.
+    ternary_expression: ($) =>
+      prec.right(
+        0,
+        seq(
+          field("condition", $._expression),
+          "?",
+          field("then", $._expression),
+          ":",
+          field("else", $._expression)
+        )
+      ),
+
+    binary_expression: ($) =>
+      choice(
+        // Right-associative exponentiation
+        prec.right(
+          7,
+          seq(
+            field("left", $._expression),
+            field("operator", "**"),
+            field("right", $._expression)
+          )
+        ),
+        // Left-associative operators
+        ...[
+          ["||", 1],
+          ["&&", 2],
+          ["==", 3],
+          ["!=", 3],
+          ["<", 4],
+          [">", 4],
+          ["<=", 4],
+          [">=", 4],
+          ["+", 5],
+          ["-", 5],
+          ["*", 6],
+          ["/", 6],
+          ["%", 6],
+        ].map(([op, p]) =>
+          prec.left(
+            /** @type {number} */ (p),
+            seq(
+              field("left", $._expression),
+              field("operator", /** @type {string} */ (op)),
+              field("right", $._expression)
+            )
+          )
+        )
+      ),
+
+    unary_expression: ($) =>
+      prec(
+        8,
+        seq(
+          field("operator", choice("-", "!")),
+          field("operand", $._expression)
+        )
+      ),
+
+    call_expression: ($) =>
+      prec(
+        9,
+        seq(
+          field("function", $.identifier),
+          "(",
+          optional(
+            seq($._argument, repeat(seq(",", $._argument)), optional(","))
+          ),
+          ")"
+        )
+      ),
+
+    // A call argument is either positional (a bare expression) or named
+    // (`key: value`). Named arguments carry the windowing/qualifier options
+    // of measurement probe functions, e.g. `max(v(out), from: 10n, to: 50n)`.
+    // Reuses the shared `named_argument` rule defined above for element args.
+    _argument: ($) => choice($.named_argument, $._expression),
+
+    paren_expression: ($) =>
+      seq("(", $._expression, repeat(seq(",", $._expression)), optional(","), ")"),
+
+    list_literal: ($) =>
+      seq("[", optional(seq($._expression, repeat(seq(",", $._expression)), optional(","))), "]"),
+
+    block_literal: ($) =>
+      seq(
+        "{",
+        optional(seq(
+          $.block_entry,
+          repeat(seq(",", $.block_entry)),
+          optional(",")
+        )),
+        "}"
+      ),
+
+    block_entry: ($) =>
+      seq(field("key", $.identifier), ":", field("value", $._expression)),
+
+    // ── Literals ─────────────────────────────────────────────────────
+
+    number_literal: (_$) =>
+      token(
+        seq(
+          choice(
+            // Hex
+            seq("0", choice("x", "X"), /[0-9a-fA-F][0-9a-fA-F_]*/),
+            // Binary
+            seq("0", choice("b", "B"), /[01][01_]*/),
+            // Decimal float/int
+            seq(
+              choice(
+                seq(/[0-9][0-9_]*/, optional(seq(".", /[0-9][0-9_]*/))),
+                seq(".", /[0-9][0-9_]*/)
+              ),
+              optional(seq(choice("e", "E"), optional(choice("+", "-")), /[0-9][0-9_]*/))
+            )
+          ),
+          // Optional SI suffix
+          optional(choice("T", "G", "Meg", "M", "k", "m", "u", "n", "p", "f"))
+        )
+      ),
+
+    string_literal: (_$) =>
+      token(seq('"', repeat(choice(/[^"\\]/, seq("\\", /./),)), '"')),
+
+    boolean_literal: (_$) => choice("true", "false"),
+
+    gnd: (_$) => "gnd",
+
+    // ── Names ────────────────────────────────────────────────────────
+
+    identifier: (_$) => /[a-zA-Z_][a-zA-Z0-9_]*/,
+
+    qualified_name: ($) =>
+      seq($.identifier, repeat1(seq(".", $.identifier))),
+
+    // ── Comments ─────────────────────────────────────────────────────
+
+    line_comment: (_$) => token(seq("//", /[^\n]*/)),
+
+    block_comment: (_$) => token(seq("/*", /[^*]*\*+([^/*][^*]*\*+)*/, "/")),
+  },
+});

--- a/langs/group-moss/cirq/def/grammar/scanner.c
+++ b/langs/group-moss/cirq/def/grammar/scanner.c
@@ -1,0 +1,353 @@
+#include "tree_sitter/parser.h"
+
+// External scanner for the cirq grammar.
+//
+// Scans a single token type: `code_body`, the raw verbatim text between
+// the braces of `code "lang" { ... }`.
+//
+// The body may contain arbitrary embedded-language code, including nested
+// `{` / `}` and string-/comment-/template-like constructs whose contents
+// must not affect the outer brace counter. This scanner walks the body
+// character-by-character so the body extends exactly to the matching `}`
+// of the `code` block.
+//
+// ─────────────────────────────────────────────────────────────────────
+// LANGUAGES SUPPORTED
+// ─────────────────────────────────────────────────────────────────────
+//
+// First-class support is for the three languages the cirq surface is
+// designed to host:
+//
+//   1. javascript — `//` line comments, `/* */` block comments, `"..."`
+//      and `'...'` strings with backslash escapes, and template literals
+//      `` `...${ expr }...` `` including nested templates inside the
+//      interpolation.
+//
+//   2. bash — `#` line comments (only at the first non-whitespace
+//      position of a line, so JS private fields `#name` aren't mis-
+//      treated), `"..."` and `'...'` strings.
+//
+//   3. control (ngspice .control) — `*` line comments at the first
+//      non-whitespace position of a line, and `"..."` strings.
+//
+// The scanner is universal across the three: every special-case rule is
+// either disjoint between the languages or guarded so a feature of one
+// language doesn't trip in another. The cases not handled are listed
+// below; they fall back to "consume as ordinary character" and so a `}`
+// inside one of them will still prematurely terminate the block.
+//
+// ─────────────────────────────────────────────────────────────────────
+// KNOWN LIMITATIONS
+// ─────────────────────────────────────────────────────────────────────
+//
+//   1. Bash heredocs (`<<EOF ... EOF`, `<<-EOF ...`, `<<"EOF" ...`).
+//      Bodies frequently embed JSON/YAML and so contain `}`. Users who
+//      need a heredoc with literal `}` inside should write the script
+//      to an external file and `source` it from the code block instead.
+//
+//   2. Python triple-quoted strings, Rust/C++ raw strings, Lua long
+//      brackets — none of the three primary languages need these.
+//
+//   3. JS regex literals (`/[}]/` in a character class). Distinguishing
+//      regex from division is context-sensitive and would require a
+//      mini-parser; skipped on the grounds that regexes containing `}`
+//      in character classes are rare in practice.
+//
+//   4. JS private fields used at the first non-whitespace position of a
+//      line with no leading dot — e.g. `#priv = 1` at the very start of
+//      a class body line. The line-comment guard already excludes
+//      `#[a-zA-Z_]` to avoid this, but `#0` or `#$` at SOL would still
+//      be misread; both are syntax errors in JS so the resulting parse
+//      error is no worse than the source's.
+//
+// ─────────────────────────────────────────────────────────────────────
+
+#include <stdbool.h>
+#include <stdint.h>
+
+enum TokenType {
+    CODE_BODY,
+};
+
+void *tree_sitter_cirq_external_scanner_create(void) {
+    return NULL;
+}
+
+void tree_sitter_cirq_external_scanner_destroy(void *payload) {
+    (void)payload;
+}
+
+unsigned tree_sitter_cirq_external_scanner_serialize(void *payload, char *buffer) {
+    (void)payload;
+    (void)buffer;
+    return 0;
+}
+
+void tree_sitter_cirq_external_scanner_deserialize(
+    void *payload, const char *buffer, unsigned length
+) {
+    (void)payload;
+    (void)buffer;
+    (void)length;
+}
+
+static inline bool is_id_start(int32_t c) {
+    return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_';
+}
+
+// Consume characters of a `"..."` or `'...'` string up to and including
+// the closing quote, honoring backslash escapes. Assumes the opening
+// quote is the current lookahead.
+//
+// Bash single-quoted strings don't actually honour `\`, but the only
+// place that matters is `'\''`, which contains no braces. Treating it
+// as an escape across the board is safe for the brace counter.
+static void consume_string(TSLexer *lexer) {
+    int32_t quote = lexer->lookahead;
+    lexer->advance(lexer, false);
+
+    while (!lexer->eof(lexer)) {
+        int32_t c = lexer->lookahead;
+
+        if (c == '\\') {
+            lexer->advance(lexer, false);
+            if (!lexer->eof(lexer)) {
+                lexer->advance(lexer, false);
+            }
+            continue;
+        }
+
+        if (c == quote) {
+            lexer->advance(lexer, false);
+            return;
+        }
+
+        lexer->advance(lexer, false);
+    }
+}
+
+// Forward declaration — template literals can nest through `${...}`.
+static void consume_template_literal(TSLexer *lexer);
+
+// Skip the interpolated `${...}` expression of a JS template literal,
+// starting from the position immediately after the `${`. Balances `{`
+// and `}` inside, and recurses through nested strings and template
+// literals so `${ \`inner ${x}\` }` works.
+static void consume_template_interpolation(TSLexer *lexer) {
+    int depth = 1;
+    while (!lexer->eof(lexer) && depth > 0) {
+        int32_t c = lexer->lookahead;
+        if (c == '"' || c == '\'') {
+            consume_string(lexer);
+            continue;
+        }
+        if (c == '`') {
+            consume_template_literal(lexer);
+            continue;
+        }
+        if (c == '{') {
+            depth++;
+            lexer->advance(lexer, false);
+            continue;
+        }
+        if (c == '}') {
+            depth--;
+            lexer->advance(lexer, false);
+            continue;
+        }
+        lexer->advance(lexer, false);
+    }
+}
+
+// Consume a JS template literal: `...${expr}...` Assumes the opening
+// backtick is the current lookahead.
+static void consume_template_literal(TSLexer *lexer) {
+    lexer->advance(lexer, false);  // opening `
+
+    while (!lexer->eof(lexer)) {
+        int32_t c = lexer->lookahead;
+
+        if (c == '\\') {
+            lexer->advance(lexer, false);
+            if (!lexer->eof(lexer)) {
+                lexer->advance(lexer, false);
+            }
+            continue;
+        }
+
+        if (c == '`') {
+            lexer->advance(lexer, false);
+            return;
+        }
+
+        if (c == '$') {
+            lexer->advance(lexer, false);
+            if (lexer->lookahead == '{') {
+                lexer->advance(lexer, false);  // past `{`
+                consume_template_interpolation(lexer);
+            }
+            continue;
+        }
+
+        lexer->advance(lexer, false);
+    }
+}
+
+// Advance past the rest of the current line. Stops at (but does not
+// consume) the terminating `\n`, so the main loop can observe the
+// newline and update the start-of-line flag.
+static void skip_to_eol(TSLexer *lexer) {
+    while (!lexer->eof(lexer) && lexer->lookahead != '\n') {
+        lexer->advance(lexer, false);
+    }
+}
+
+// Skip from inside a `/*` block comment to past the closing `*/`. The
+// caller has already consumed the opening `/*`.
+static void skip_block_comment(TSLexer *lexer) {
+    while (!lexer->eof(lexer)) {
+        int32_t c = lexer->lookahead;
+        lexer->advance(lexer, false);
+        if (c == '*' && lexer->lookahead == '/') {
+            lexer->advance(lexer, false);
+            return;
+        }
+    }
+}
+
+bool tree_sitter_cirq_external_scanner_scan(
+    void *payload, TSLexer *lexer, const bool *valid_symbols
+) {
+    (void)payload;
+
+    if (!valid_symbols[CODE_BODY]) {
+        return false;
+    }
+
+    // Skip leading whitespace without including it in the token. We don't
+    // want the body to start with a run of spaces/newlines, because the
+    // grammar's `extras` would normally handle them at this position;
+    // refusing to consume them here lets the parser apply extras and
+    // call us back at the first non-whitespace character.
+    while (!lexer->eof(lexer)) {
+        int32_t c = lexer->lookahead;
+        if (c == ' ' || c == '\t' || c == '\n' || c == '\r') {
+            lexer->advance(lexer, true);
+        } else {
+            break;
+        }
+    }
+
+    // If the next character is the closing brace of the `code` block at
+    // depth 0, the body is empty. Refuse the token so that the optional()
+    // in the grammar lets the outer `}` close the block directly.
+    if (lexer->eof(lexer) || lexer->lookahead == '}') {
+        return false;
+    }
+
+    int depth = 0;
+    bool consumed_any = false;
+    bool at_sol = true;  // first non-whitespace position of the line
+
+    while (!lexer->eof(lexer)) {
+        int32_t c = lexer->lookahead;
+
+        if (c == '}' && depth == 0) {
+            // Reached the closing brace of the `code` block. Stop without
+            // consuming it — the outer grammar will match the `}` token.
+            break;
+        }
+
+        consumed_any = true;
+
+        // Newline / whitespace handling has to come before the at_sol
+        // reset so that runs of `   #comment` and `\t* comment` still
+        // count as starting-of-line. Tabs/spaces leave at_sol alone.
+        if (c == '\n') {
+            at_sol = true;
+            lexer->advance(lexer, false);
+            continue;
+        }
+        if (c == ' ' || c == '\t' || c == '\r') {
+            lexer->advance(lexer, false);
+            continue;
+        }
+
+        bool was_at_sol = at_sol;
+        at_sol = false;
+
+        switch (c) {
+            case '"':
+            case '\'':
+                consume_string(lexer);
+                break;
+
+            case '`':
+                consume_template_literal(lexer);
+                break;
+
+            case '/': {
+                lexer->advance(lexer, false);
+                int32_t next = lexer->lookahead;
+                if (next == '/') {
+                    skip_to_eol(lexer);
+                } else if (next == '*') {
+                    lexer->advance(lexer, false);
+                    skip_block_comment(lexer);
+                }
+                // else: a plain `/`. Already consumed.
+                break;
+            }
+
+            case '#': {
+                if (was_at_sol) {
+                    lexer->advance(lexer, false);
+                    // Guard JS private-field syntax: `#priv` at SOL is
+                    // not a comment, it's an identifier. Anything else
+                    // (`#!`, `# `, `##`, `#0`) treats the rest of the
+                    // line as a comment.
+                    if (!is_id_start(lexer->lookahead)) {
+                        skip_to_eol(lexer);
+                    }
+                } else {
+                    lexer->advance(lexer, false);
+                }
+                break;
+            }
+
+            case '*': {
+                if (was_at_sol) {
+                    // ngspice .control line comment. Consume from `*`
+                    // through the rest of the line.
+                    skip_to_eol(lexer);
+                } else {
+                    lexer->advance(lexer, false);
+                }
+                break;
+            }
+
+            case '{':
+                depth++;
+                lexer->advance(lexer, false);
+                break;
+
+            case '}':
+                // depth > 0 here; this `}` closes a nested block inside
+                // the embedded language.
+                depth--;
+                lexer->advance(lexer, false);
+                break;
+
+            default:
+                lexer->advance(lexer, false);
+                break;
+        }
+    }
+
+    if (!consumed_any) {
+        return false;
+    }
+
+    lexer->result_symbol = CODE_BODY;
+    return true;
+}

--- a/langs/group-moss/cirq/def/queries/highlights.scm
+++ b/langs/group-moss/cirq/def/queries/highlights.scm
@@ -1,0 +1,165 @@
+; Cirq tree-sitter highlights
+; ============================================================
+
+; ── Keywords ─────────────────────────────────────────────────
+
+[
+  "circuit"
+  "module"
+  "port"
+  "param"
+  "let"
+  "model"
+  "analysis"
+  "import"
+  "as"
+  "global"
+  "sweep"
+  "step"
+  "code"
+] @keyword
+
+; ── Code blocks ──────────────────────────────────────────────
+; The language tag is conceptually a type-like marker rather than
+; a string literal, so highlight it distinctly. The body is left
+; unhighlighted here — injections.scm hands it off to the embedded
+; language's own highlight queries.
+
+(code_decl
+  language: (string_literal) @string.special)
+
+; Port directions
+(port_direction) @keyword
+
+; ── Literals ─────────────────────────────────────────────────
+
+(number_literal) @number
+(string_literal) @string
+(boolean_literal) @boolean
+
+; gnd is a built-in constant
+(gnd) @constant.builtin
+
+; ── Comments ─────────────────────────────────────────────────
+
+(line_comment) @comment
+(block_comment) @comment
+
+; ── Operators ────────────────────────────────────────────────
+
+(binary_expression
+  operator: _ @operator)
+
+(unary_expression
+  operator: _ @operator)
+
+"->" @operator
+".." @operator
+"=" @operator
+
+; ── Punctuation ──────────────────────────────────────────────
+
+"(" @punctuation.bracket
+")" @punctuation.bracket
+"{" @punctuation.bracket
+"}" @punctuation.bracket
+"[" @punctuation.bracket
+"]" @punctuation.bracket
+
+"," @punctuation.delimiter
+":" @punctuation.delimiter
+"." @punctuation.delimiter
+
+; ── Attributes ───────────────────────────────────────────────
+
+(attribute
+  "@" @attribute
+  name: (identifier) @attribute)
+
+; ── Declaration heads ────────────────────────────────────────
+
+(circuit_decl
+  name: (identifier) @type.definition)
+
+(module_decl
+  name: (identifier) @type.definition)
+
+(model_decl
+  name: (identifier) @type.definition)
+
+(model_decl
+  device_type: (identifier) @type)
+
+(module_decl
+  base: (identifier) @type)
+
+; ── Port declarations ────────────────────────────────────────
+
+(port_decl
+  name: (identifier) @variable)
+
+; ── Parameter and let declarations ───────────────────────────
+
+(param_decl
+  name: (identifier) @variable)
+
+(param_decl
+  type: (identifier) @type)
+
+(let_decl
+  name: (identifier) @variable)
+
+(global_decl
+  name: (identifier) @variable)
+
+; ── Element and module instances ─────────────────────────────
+
+(element_inst
+  name: (identifier) @variable)
+
+(element_inst
+  type: (identifier) @type)
+
+(module_inst
+  name: (identifier) @variable)
+
+(module_inst
+  module: (qualified_name) @type)
+
+; ── Analysis ─────────────────────────────────────────────────
+
+(analysis_decl
+  kind: (identifier) @type)
+
+(analysis_setting
+  name: (identifier) @property)
+
+(sweep_spec
+  source: (identifier) @variable)
+
+; ── Model parameters ─────────────────────────────────────────
+
+(model_param
+  name: (identifier) @property)
+
+; ── Named arguments ──────────────────────────────────────────
+
+(named_argument
+  name: (identifier) @property)
+
+(named_connection
+  name: (identifier) @property)
+
+; ── Block literal entries ────────────────────────────────────
+
+(block_entry
+  key: (identifier) @property)
+
+; ── Function calls ───────────────────────────────────────────
+
+(call_expression
+  function: (identifier) @function.builtin)
+
+; ── Identifiers (fallback) ───────────────────────────────────
+
+(identifier) @variable

--- a/langs/group-moss/cirq/def/queries/injections.scm
+++ b/langs/group-moss/cirq/def/queries/injections.scm
@@ -1,0 +1,78 @@
+; Cirq tree-sitter language injections
+; ============================================================
+;
+; Inject embedded-language highlighting / parsing into the body of
+; `code "lang" { ... }` blocks. The language string inside the
+; quotes selects which grammar to use for the body.
+;
+; Editors look up the injected grammar by the exact captured text,
+; so well-known short names are mapped to their canonical grammar
+; name below. Anything not aliased falls through to the generic
+; rule at the bottom, which strips the surrounding quotes and uses
+; the string verbatim — so `code "rust" {}` or `code "python" {}`
+; just work.
+
+; ── Aliases ──────────────────────────────────────────────────
+
+((code_decl
+  language: (string_literal) @_lang
+  body: (code_body) @injection.content)
+ (#any-of? @_lang "\"js\"" "\"jsx\"")
+ (#set! injection.language "javascript")
+ (#set! injection.combined))
+
+((code_decl
+  language: (string_literal) @_lang
+  body: (code_body) @injection.content)
+ (#any-of? @_lang "\"ts\"" "\"tsx\"")
+ (#set! injection.language "typescript")
+ (#set! injection.combined))
+
+((code_decl
+  language: (string_literal) @_lang
+  body: (code_body) @injection.content)
+ (#eq? @_lang "\"py\"")
+ (#set! injection.language "python")
+ (#set! injection.combined))
+
+((code_decl
+  language: (string_literal) @_lang
+  body: (code_body) @injection.content)
+ (#eq? @_lang "\"rs\"")
+ (#set! injection.language "rust")
+ (#set! injection.combined))
+
+((code_decl
+  language: (string_literal) @_lang
+  body: (code_body) @injection.content)
+ (#eq? @_lang "\"sh\"")
+ (#set! injection.language "bash")
+ (#set! injection.combined))
+
+((code_decl
+  language: (string_literal) @_lang
+  body: (code_body) @injection.content)
+ (#eq? @_lang "\"control\"")
+ (#set! injection.language "cirq-control")
+ (#set! injection.combined))
+
+((code_decl
+  language: (string_literal) @_lang
+  body: (code_body) @injection.content)
+ (#eq? @_lang "\"md\"")
+ (#set! injection.language "markdown")
+ (#set! injection.combined))
+
+; ── Generic fallback ─────────────────────────────────────────
+; Strip the surrounding quotes from the string literal and use
+; the inner text as the injection language. Excluded short names
+; are handled by the alias rules above.
+
+((code_decl
+  language: (string_literal) @injection.language
+  body: (code_body) @injection.content)
+ (#not-any-of? @injection.language
+   "\"js\"" "\"jsx\"" "\"ts\"" "\"tsx\""
+   "\"py\"" "\"rs\"" "\"sh\"" "\"md\"" "\"control\"")
+ (#offset! @injection.language 0 1 0 -1)
+ (#set! injection.combined))

--- a/langs/group-moss/cirq/def/queries/locals.scm
+++ b/langs/group-moss/cirq/def/queries/locals.scm
@@ -1,0 +1,44 @@
+; Cirq tree-sitter locals
+; ============================================================
+; Captures structural scoping for params, lets, ports, and instances.
+
+; ── Scopes ───────────────────────────────────────────────────
+
+(circuit_decl) @local.scope
+(module_decl) @local.scope
+(analysis_decl) @local.scope
+
+; ── Definitions ──────────────────────────────────────────────
+
+; Parameters define names in their enclosing scope
+(param_decl
+  name: (identifier) @local.definition)
+
+; Let bindings define names in their enclosing scope
+(let_decl
+  name: (identifier) @local.definition)
+
+; Port declarations define names in their module scope
+(port_decl
+  name: (identifier) @local.definition)
+
+; Global net declarations define names
+(global_decl
+  name: (identifier) @local.definition)
+
+; Element instances define named components
+(element_inst
+  name: (identifier) @local.definition)
+
+; Module instances define named components
+(module_inst
+  name: (identifier) @local.definition)
+
+; Model declarations define named models
+(model_decl
+  name: (identifier) @local.definition)
+
+; ── References ───────────────────────────────────────────────
+
+; Identifiers in expression positions are references
+(identifier) @local.reference

--- a/langs/group-moss/cirq/def/samples/cmos_inverter.cirq
+++ b/langs/group-moss/cirq/def/samples/cmos_inverter.cirq
@@ -1,0 +1,32 @@
+// CMOS inverter with transient analysis.
+
+circuit cmos_inverter {
+    model nch: nmos {
+        level = 1
+        vto = 0.7
+        kp = 110u
+        lambda = 0.04
+    }
+
+    model pch: pmos {
+        level = 1
+        vto = -0.7
+        kp = 55u
+        lambda = 0.04
+    }
+
+    param vdd_voltage = 1.8
+
+    Vdd: vsource(vdd -> gnd, dc: vdd_voltage)
+    Vin: vsource(in -> gnd,
+        pulse: { v1: 0, v2: 1.8, td: 0, tr: 1n, tf: 1n, pw: 5n, per: 10n }
+    )
+
+    M1: pmos(drain: out, gate: in, source: vdd, bulk: vdd, model: pch, w: 2u, l: 180n)
+    M2: nmos(drain: out, gate: in, source: gnd, bulk: gnd, model: nch, w: 1u, l: 180n)
+
+    analysis tran {
+        step: 100p
+        stop: 20n
+    }
+}

--- a/langs/group-moss/cirq/def/samples/conditional.cirq
+++ b/langs/group-moss/cirq/def/samples/conditional.cirq
@@ -1,0 +1,45 @@
+// Compile-time `if / elseif / else`.
+//
+// These blocks are resolved at lowering time — the condition is a constant
+// expression over params/literals, and only the taken branch's declarations
+// reach the simulator. This is the native counterpart of SPICE's
+// `.if/.elseif/.else/.endif`, and is distinct from the runtime ternary
+// (`cond ? a : b`) and from `.control` script `if`.
+
+circuit amp {
+    param corner = "tt"        // process corner: ff | tt | ss
+    param vdd = 1.8
+    param fast = true
+
+    // Conditional parameter selection — string equality folds at compile time.
+    if corner == "ff" {
+        param vto = 0.35
+    } elseif corner == "ss" {
+        param vto = 0.55
+    } else {
+        param vto = 0.45
+    }
+
+    // Conditional element inclusion: the protection resistor only exists when
+    // the supply is high enough to need it.
+    if vdd > 1.5 {
+        Rprot: resistor(in -> gate, 10k)
+    }
+
+    V1: vsource(in -> gnd, dc: vdd)
+    R1: resistor(in -> out, 1k)
+    C1: capacitor(out -> gnd, 1p)
+
+    // Branch bodies hold any circuit item, including whole analyses.
+    if fast {
+        analysis tran {
+            step: 10p
+            stop: 5n
+        }
+    } else {
+        analysis tran {
+            step: 100p
+            stop: 50n
+        }
+    }
+}

--- a/langs/group-moss/cirq/def/samples/fourier.cirq
+++ b/langs/group-moss/cirq/def/samples/fourier.cirq
@@ -1,0 +1,33 @@
+// Native Fourier / FFT post-processing.
+//
+// `analysis four` and `analysis fft` are spelled as analysis kinds, just like
+// `tran` and `ac`. Both post-process the preceding `analysis tran`, so a
+// transient is declared alongside them. They are the native counterparts of
+// SPICE `.four` and `.fft`.
+
+circuit sine_rc {
+    // 1 kHz sine into an RC low-pass.
+    V1: vsource(in -> gnd, sin: { v0: 0, va: 1, freq: 1k })
+    R1: resistor(in -> out, 1k)
+    C1: capacitor(out -> gnd, 100n)
+
+    analysis tran {
+        step: 5u
+        stop: 5m
+    }
+
+    // Harmonic table of the final fundamental period → `fourier1` plot.
+    analysis four {
+        fundamental: 1k
+        output: v(out)
+        harmonics: 9
+    }
+
+    // Windowed FFT over the transient → `fft1` plot. `output` accepts a list.
+    analysis fft {
+        output: [v(out), v(in)]
+        npoints: 1024
+        window: hann
+        format: magnitude
+    }
+}

--- a/langs/group-moss/cirq/def/samples/hierarchical.cirq
+++ b/langs/group-moss/cirq/def/samples/hierarchical.cirq
@@ -1,0 +1,51 @@
+// Hierarchical design: a buffer made of two inverters.
+
+module inverter {
+    port in: in
+    port out: out
+    port vdd: inout
+    port vss: inout
+
+    param wp = 2u
+    param wn = 1u
+    param l = 180n
+
+    M1: pmos(drain: out, gate: in, source: vdd, bulk: vdd, model: pch, w: wp, l: l)
+    M2: nmos(drain: out, gate: in, source: vss, bulk: vss, model: nch, w: wn, l: l)
+}
+
+module buffer {
+    port a: in
+    port z: out
+    port vdd: inout
+    port vss: inout
+
+    inv1: inverter(in: a, out: mid, vdd: vdd, vss: vss)
+    inv2: inverter(in: mid, out: z, vdd: vdd, vss: vss)
+}
+
+circuit buffer_test {
+    model nch: nmos {
+        level = 1
+        vto = 0.7
+        kp = 110u
+    }
+
+    model pch: pmos {
+        level = 1
+        vto = -0.7
+        kp = 55u
+    }
+
+    Vdd: vsource(vdd -> gnd, dc: 1.8)
+    Vin: vsource(in -> gnd,
+        pulse: { v1: 0, v2: 1.8, td: 0, tr: 100p, tf: 100p, pw: 5n, per: 10n }
+    )
+
+    buf1: buffer(a: in, z: out, vdd: vdd, vss: gnd)
+
+    analysis tran {
+        step: 50p
+        stop: 30n
+    }
+}

--- a/langs/group-moss/cirq/def/samples/voltage_divider.cirq
+++ b/langs/group-moss/cirq/def/samples/voltage_divider.cirq
@@ -1,0 +1,11 @@
+// Simple voltage divider — the "hello world" of circuit simulation.
+
+circuit voltage_divider {
+    param vdd = 5
+
+    V1: vsource(in -> gnd, dc: vdd)
+    R1: resistor(in -> mid, 1k)
+    R2: resistor(mid -> gnd, 2k)
+
+    analysis op {}
+}


### PR DESCRIPTION
## Summary

Adds two tree-sitter grammars from the [Thevenin](https://github.com/cramt/thevenin) SPICE simulator, following [ADDING_GRAMMARS.md](../blob/main/ADDING_GRAMMARS.md):

- **`cirq`** (`group-moss`) — the **Cirq** circuit-description language: circuits, reusable modules, parameters, device models, and analysis declarations. Sits alongside the existing hardware-description languages (Verilog, VHDL). Ships an external scanner for brace-counting `code "lang" { … }` embedded-language blocks, plus `highlights` / `injections` / `locals` queries.
- **`cirq-control`** (`group-hazel`) — the ngspice **`.control`** scripting language: `let`/`print`/`run`/`measure` statements with `if`/`while`/`repeat`/`foreach` blocks and a shared vector-expression sublanguage.

Both are **tier 5**, **BSD-3-Clause** (permissive → default-included).

## Notes

- The grammar's internal name for the control language is `control`, so its config pins `c_symbol: control` to match the generated `tree_sitter_control` symbol.
- Cirq's `code "control" { … }` injection sets `injection.language "cirq-control"` so it resolves to the registered arborium id. All other injection targets (javascript/typescript/python/rust/bash/markdown) already exist in the registry.

## Test plan

- [x] `cargo xtask gen cirq` and `cargo xtask gen cirq-control` — generate cleanly
- [x] `cargo xtask lint` — passes (one advisory: the deliberately-minimal `voltage_divider.cirq` hello-world is <25 lines)
- [x] `cargo xtask grammar-test cirq` / `cirq-control` — `test_grammar` passes (validates all query files against the grammar and parses every sample)
- [x] `cargo xtask ci generate` — regenerated `.github/workflows/ci.yml` to include both languages