### PR TITLE
markdown: highlight GFM + block constructs (nvim-treesitter capture names)

### DIFF
--- a/langs/group-willow/markdown/def/queries/highlights.scm
+++ b/langs/group-willow/markdown/def/queries/highlights.scm
@@ -50,3 +50,29 @@
 [
   (backslash_escape)
 ] @string.escape
+
+(task_list_marker_checked) @markup.list.checked
+(task_list_marker_unchecked) @markup.list.unchecked
+
+(pipe_table_header
+  (pipe_table_cell) @markup.heading)
+
+(pipe_table_header "|" @punctuation.special)
+(pipe_table_row "|" @punctuation.special)
+(pipe_table_delimiter_row "|" @punctuation.special)
+(pipe_table_delimiter_cell) @punctuation.special
+[
+  (pipe_table_align_left)
+  (pipe_table_align_right)
+] @punctuation.delimiter
+
+(block_quote) @markup.quote
+
+[
+  (minus_metadata)
+  (plus_metadata)
+] @keyword.directive
+
+(fenced_code_block
+  (info_string
+    (language) @label))

--- a/langs/group-willow/markdown/def/sample.md
+++ b/langs/group-willow/markdown/def/sample.md
@@ -1,12 +1,35 @@
+---
+title: Arborium Markdown Demo
+draft: false
+tags: [markdown, gfm]
+---
+
 # Project Title
 
 A brief description of the project.
+
+> **Note:** this is a block quote.
+> It can span multiple lines.
 
 ## Features
 
 - **Fast**: Optimized for performance
 - **Flexible**: Works with any framework
 - *Reliable*: Battle-tested in production
+
+## Roadmap
+
+- [x] Initial release
+- [x] WASM support
+- [ ] Streaming API
+- [ ] Plugin system
+
+## Comparison
+
+| Feature     | This    | Others |
+| :---------- | :-----: | -----: |
+| Speed       | Fast    | Slow   |
+| Size        | Small   | Large  |
 
 ## Installation
 


### PR DESCRIPTION
## What

The markdown grammar's `highlights.scm` had no rules for several block-level
constructs the grammar already parses. This adds captures for them, using the
standard nvim-treesitter capture names:

- **Task list markers** → `markup.list.checked` / `markup.list.unchecked`
- **Pipe tables** → header cells `markup.heading`; `|` separators and delimiter
  cells `punctuation.special`; alignment colons `punctuation.delimiter` (via the
  grammar's `pipe_table_align_left` / `pipe_table_align_right` aliases of `:`)
- **Block quotes** → `markup.quote`
- **YAML / TOML front matter** → `keyword.directive` (the injections query still
  colors the inner YAML/TOML where a consumer resolves injections)
- **Fenced code block language** → `label`

The bundled `sample.md` is extended with front matter, a block quote, a task
list, and a table so it represents these constructs.

## Testing

- `cargo xtask gen markdown`
- `cargo xtask lint`
- `cargo xtask grammar-test markdown` → 2 passed (validates the query compiles
  against the grammar)
- `cargo xtask build markdown --dev` — WASM plugin builds
- Visually verified in `cargo xtask serve --dev`
