### PR TITLE
fix(cobol): guard the LINE_PREFIX_COMMENT scan against end of file

### DIFF
--- a/langs/group-rowan/cobol/def/corpus/sequence_area.txt
+++ b/langs/group-rowan/cobol/def/corpus/sequence_area.txt
@@ -1,0 +1,23 @@
+=== sequence area truncated at end of file
+--- input
+aaaaaa identification division.
+aaaaaa program-id. a.
+aaa
+--- contains
+program_definition
+identification_division
+program_name
+--- sexp
+(start (program_definition (identification_division (IDENTIFICATION) (DIVISION) (program_name))))
+
+=== sequence area is the whole final line
+--- input
+aaaaaa identification division.
+aaaaaa program-id. a.
+aaaaaa
+--- contains
+program_definition
+identification_division
+program_name
+--- sexp
+(start (program_definition (identification_division (IDENTIFICATION) (DIVISION) (program_name))))

--- a/langs/group-rowan/cobol/def/grammar/scanner.c
+++ b/langs/group-rowan/cobol/def/grammar/scanner.c
@@ -170,8 +170,17 @@ bool tree_sitter_cobol_external_scanner_scan(void *payload, TSLexer *lexer,
     }
 
     if(valid_symbols[LINE_PREFIX_COMMENT] && lexer->get_column(lexer) <= 5) {
-        while(lexer->get_column(lexer) <= 5) {
+        // The column can only advance while input remains: at end of file
+        // `advance` is a no-op, so testing the column alone spins forever.
+        bool consumed_any = false;
+        while(lexer->lookahead != 0 && lexer->get_column(lexer) <= 5) {
             lexer->advance(lexer, true);
+            consumed_any = true;
+        }
+        // Never emit a zero-width token: the parser would re-enter the scanner
+        // at the same position and loop just as tightly.
+        if(!consumed_any) {
+            return false;
         }
         lexer->result_symbol = LINE_PREFIX_COMMENT;
         lexer->mark_end(lexer);


### PR DESCRIPTION
## Problem

`arborium-cobol` can hang forever. The vendored tree-sitter-cobol external scanner loops on the column alone in its `LINE_PREFIX_COMMENT` branch:

```c
while(lexer->get_column(lexer) <= 5) {
    lexer->advance(lexer, true);
}
```

At end of file `advance` is a no-op, so the column freezes at ≤5, never reaches 6, and the scanner spins at 100% CPU. Every other column-gated loop in that file already tests `lexer->lookahead != 0`; this one does not.

Because tree-sitter marks all external tokens valid during error recovery, any input entering recovery with fewer than six columns before EOF reaches this branch. It is triggered by **content, not size** — a one-byte file containing `!` is enough. A realistic trigger is a fixed-format file whose last line is a truncated sequence area, which is what the added corpus cases cover.

The spin is inside `external_scanner_scan`, so it cannot be interrupted by the consumer: `ParseOptions::progress_callback` never fires and a wall-clock budget does not rescue it (measured 135s CPU against a 5s budget, stopped only by SIGKILL). A single file can therefore wedge a whole batch ingest with no timeout available as a workaround.

## Fix

Stop the loop when the input is exhausted, and return `false` rather than emitting a zero-width token — emitting one would put the parser back into the scanner at the same position and loop just as tightly.

## Tests

Adds `langs/group-rowan/cobol/def/corpus/sequence_area.txt`. This is the first grammar to use the harness's `corpus/` mechanism, which `xtask` already wires up (`has_corpus` → generated `tests/corpus.rs`, and `generate.rs` copies `def/corpus` into the crate). No generator changes were needed.

```
$ cargo test -p arborium-cobol
test [corpus] corpus/sequence_area.txt::sequence area truncated at end of file ... ok
test [corpus] corpus/sequence_area.txt::sequence area is the whole final line  ... ok
test result: ok. 2 passed; 0 failed
```

Both cases hang on `main` and pass with this patch. Verified via `cargo xtask gen cobol` and a full `cargo xtask gen` (122 crates) with tree-sitter CLI 0.26.3.

## Impact

Found while running COBOL through this grammar at scale. Against the published [CMS IPF Pricer](https://github.com/CoreStory-Frontier/corpus-cobol-cms-ipf) corpus, **all 41 files hung**; with this patch all 41 parse, two of them cleanly (`has_error=false`).

A differential test over **157 real COBOL files** (AWS CardDemo + CMS IPF), comparing full parse-tree fingerprints before and after: **116 byte-identical, 41 rescued from hanging, 0 changed.** No successful parse is altered by this patch.

## Upstream

The same fix is filed against the grammar this vendors from, and against its canonical root:

- `zharinov/tree-sitter-cobol` (the commit pinned in `def/arborium.yaml`): https://github.com/zharinov/tree-sitter-cobol/pull/1 — `tree-sitter test` 81/81, NIST COBOL85 unchanged at 382/371/0/11
- `yutaro-sakamoto/tree-sitter-cobol` (canonical): same bug, PR filed

Landing it upstream matters here because a future `arborium.yaml` commit bump would otherwise silently re-introduce the hang.