### PR TITLE
Add LuaCATS / EmmyLuaDoc support to Lua

### DIFF
--- a/crates/arborium/tests/lua.rs
+++ b/crates/arborium/tests/lua.rs
@@ -1,0 +1,36 @@
+//! Lua documentation-comment injection tests.
+
+#![cfg(all(feature = "lang-lua", feature = "lang-emmyluadoc"))]
+
+use arborium::Highlighter;
+use arborium_highlight::Span;
+
+fn has_exact_capture(spans: &[Span], source: &str, text: &str, capture: &str) -> bool {
+    spans.iter().any(|span| {
+        span.capture == capture && source.get(span.start as usize..span.end as usize) == Some(text)
+    })
+}
+
+#[test]
+fn highlights_emmylua_annotations_inside_lua_comments() {
+    let source = "---@class Person\n---@field name string\nlocal person = {}\n";
+    let spans = Highlighter::new().highlight_spans("lua", source).unwrap();
+
+    assert!(has_exact_capture(&spans, source, "@class", "keyword"));
+    assert!(has_exact_capture(
+        &spans,
+        source,
+        "Person",
+        "type.definition"
+    ));
+    assert!(has_exact_capture(&spans, source, "name", "variable.member"));
+    assert!(has_exact_capture(&spans, source, "string", "type.builtin"));
+}
+
+#[test]
+fn leaves_ordinary_lua_comments_as_comments() {
+    let source = "-- @class NotDocumentation\nlocal value = 1\n";
+    let spans = Highlighter::new().highlight_spans("lua", source).unwrap();
+
+    assert!(!has_exact_capture(&spans, source, "@class", "keyword"));
+}

--- a/langs/group-hazel/emmyluadoc/def/arborium.yaml
+++ b/langs/group-hazel/emmyluadoc/def/arborium.yaml
@@ -1,0 +1,23 @@
+repo: https://github.com/EmmyLuaLs/tree-sitter-emmyluadoc
+commit: ea755c0fd34c07e16597bd62a404d6eba2a3891e
+license: MIT
+
+grammars:
+  - id: emmyluadoc
+    name: EmmyLuaDoc
+    tag: code
+    tier: 3
+    has_scanner: true
+    icon: devicon-plain:lua
+
+    inventor: CppCXY
+    year: 2025
+    description: "LuaCATS / EmmyLua are type annotations embedded in Lua doc comments."
+    link: https://github.com/EmmyLuaLs/tree-sitter-emmyluadoc
+    trivia: "LuaCATS is a cuter name that EmmyLuaDoc"
+
+    samples:
+      - path: samples/luadoc.lua
+        description: Lua script demonstrating type info in comments
+        link: https://github.com/EmmyLuaLs/tree-sitter-emmyluadoc/blob/main/README.md
+        license: MIT

--- a/langs/group-hazel/emmyluadoc/def/arborium.yaml
+++ b/langs/group-hazel/emmyluadoc/def/arborium.yaml
@@ -10,10 +10,10 @@ grammars:
     has_scanner: true
     icon: devicon-plain:lua
 
-    inventor: CppCXY
+    inventor: tangzx
     year: 2025
-    description: "LuaCATS / EmmyLua are type annotations embedded in Lua doc comments."
-    link: https://github.com/EmmyLuaLs/tree-sitter-emmyluadoc
+    description: "Lua Comment and Typs System where EmmyLuaDoc/LuaCATS annotations are embedded in Lua comments."
+    link: https://luals.github.io/wiki/annotations/
     trivia: "LuaCATS is a cuter name that EmmyLuaDoc"
 
     samples:

--- a/langs/group-hazel/emmyluadoc/def/grammar/grammar.js
+++ b/langs/group-hazel/emmyluadoc/def/grammar/grammar.js
@@ -1,0 +1,638 @@
+module.exports = grammar({
+  name: 'emmyluadoc',
+
+  externals: $ => [
+    $.text_line,
+    $.description
+  ],
+
+  extras: $ => [
+    /\s/
+  ],
+
+  word: $ => $.identifier,
+
+  rules: {
+    // Root rule of the document
+    source: $ => repeat(choice(
+      $.text_line,
+      $.annotation,
+      $.type_continuation
+    )),
+
+    // Plain text line (handled by external scanner)
+    // Matches lines that don't start with valid annotation patterns
+
+    // Lua comment prefix (must be exactly three dashes, optionally followed by space)
+    comment_prefix: $ => token(/-{3}[ \t]*/),
+
+    // Annotation (must have comment_prefix followed by @ or @[)
+    annotation: $ => seq(
+      $.comment_prefix,
+      choice(
+        $.class_annotation,
+        $.field_annotation,
+        $.type_annotation,
+        $.param_annotation,
+        $.return_annotation,
+        $.generic_annotation,
+        $.overload_annotation,
+        $.deprecated_annotation,
+        $.see_annotation,
+        $.alias_annotation,
+        $.enum_annotation,
+        $.module_annotation,
+        $.private_annotation,
+        $.protected_annotation,
+        $.public_annotation,
+        $.package_annotation,
+        $.async_annotation,
+        $.cast_annotation,
+        $.nodiscard_annotation,
+        $.meta_annotation,
+        $.version_annotation,
+        $.diagnostic_annotation,
+        $.operator_annotation,
+        $.source_annotation,
+        $.namespace_annotation,
+        $.using_annotation,
+        $.export_annotation,
+        $.language_annotation,
+        $.attribute_annotation,
+        $.readonly_annotation,
+        $.as_annotation,
+        $.attribute_use,
+        $.other_annotation,  // Fallback for unknown annotations
+      )
+    ),
+
+    // Type continuation (--- | <type>)
+    type_continuation: $ => seq(
+      $.comment_prefix,
+      '|',
+      field('type', $.type_list),
+      optional(field('description', $.continuation_description))
+    ),
+
+    // Continuation description (starts with #)
+    continuation_description: $ => token(seq(
+      '#',
+      /[^\n\r]*/
+    )),
+
+    // @class annotation
+    class_annotation: $ => seq(
+      choice('@class', '@interface'),
+      optional(field('modifier', choice(
+        seq('(', 'exact', ')'),
+        seq('(', 'partial', ')'),
+        seq('(', 'constructor', ')')
+      ))),
+      field('name', $.identifier),
+      optional(field('generics', $.generic_params)),
+      optional(seq(':', field('parent', $.type_list)))
+    ),
+
+    // Generic parameter list (for class and alias)
+    generic_params: $ => seq(
+      '<',
+      field('params', seq(
+        $.identifier,
+        repeat(seq(',', $.identifier))
+      )),
+      '>'
+    ),
+
+    // @field annotation
+    field_annotation: $ => seq(
+      '@field',
+      optional(field('visibility', choice('public', 'private', 'protected', 'package'))),
+      choice(
+        // Named field: [access] name[?] type [description]
+        seq(
+          field('name', $.field_name),
+          field('type', $.type_annotation_value),
+          optional(field('description', $.description))
+        ),
+        // Index signature: [access] [key_type] value_type [description]
+        seq(
+          '[',
+          field('key_type', $.type),
+          ']',
+          field('value_type', $.type),
+          optional(field('description', $.description))
+        )
+      )
+    ),
+
+    // Field name (can have optional marker, supports hyphens and dots)
+    field_name: $ => token(seq(
+      /[a-zA-Z_][a-zA-Z0-9_\.\-]*/,
+      optional('?')
+    )),
+
+    // @type annotation
+    type_annotation: $ => seq(
+      '@type',
+      field('type', $.type_annotation_value)
+    ),
+
+    // @param annotation
+    param_annotation: $ => seq(
+      '@param',
+      field('name', $.param_name),
+      field('type', $.type_annotation_value),
+      optional(field('description', $.description))
+    ),
+
+    // Parameter name (can have optional marker or vararg marker, supports hyphens and dots)
+    param_name: $ => token(choice(
+      seq(/[a-zA-Z_][a-zA-Z0-9_\.\-]*/, optional('?')),
+      '...'
+    )),
+
+    // @return annotation
+    return_annotation: $ => seq(
+      '@return',
+      $.return_value,
+      repeat(seq(',', $.return_value))
+    ),
+
+    // Return value definition
+    return_value: $ => seq(
+      field('type', $.return_type_annotation),
+      optional(field('description', $.description))
+    ),
+
+    // @generic annotation
+    generic_annotation: $ => seq(
+      '@generic',
+      field('name', $.identifier),
+      optional(seq(':', field('constraint', $.type_annotation_value))),
+      repeat(seq(
+        ',',
+        field('name', $.identifier),
+        optional(seq(':', field('constraint', $.type_annotation_value)))
+      ))
+    ),
+
+    // @overload annotation
+    overload_annotation: $ => seq(
+      '@overload',
+      field('signature', $.function_type)
+    ),
+
+    // @deprecated annotation
+    deprecated_annotation: $ => seq(
+      '@deprecated',
+      optional(field('description', $.description))
+    ),
+
+    // @see annotation
+    see_annotation: $ => seq(
+      '@see',
+      choice(
+        seq(
+          field('reference', $.identifier),
+          optional(field('description', $.description))
+        ),
+        field('description', $.description)
+      )
+    ),
+
+    // @alias annotation
+    alias_annotation: $ => seq(
+      '@alias',
+      field('name', $.identifier),
+      optional(field('generics', $.generic_params)),
+      field('type', $.type_annotation_value)
+    ),
+
+    // @enum annotation
+    enum_annotation: $ => seq(
+      '@enum',
+      optional(field('modifier', seq('(', 'key', ')'))),
+      field('name', $.identifier)
+    ),
+
+    // @module annotation
+    module_annotation: $ => seq(
+      '@module',
+      field('name', $.string)
+    ),
+
+    // @private annotation
+    private_annotation: $ => '@private',
+
+    // @protected annotation
+    protected_annotation: $ => '@protected',
+
+    // @public annotation
+    public_annotation: $ => '@public',
+
+    // @package annotation
+    package_annotation: $ => '@package',
+
+    // @async annotation
+    async_annotation: $ => '@async',
+
+    // @cast annotation
+    cast_annotation: $ => seq(
+      '@cast',
+      field('name', $.identifier),
+      field('type', $.type_annotation_value)
+    ),
+
+    // @nodiscard annotation
+    nodiscard_annotation: $ => '@nodiscard',
+
+    // @meta annotation
+    meta_annotation: $ => '@meta',
+
+    // @version annotation
+    version_annotation: $ => seq(
+      '@version',
+      field('version', choice($.identifier, $.string, $.version_range)),
+      optional(field('description', $.description))
+    ),
+
+    // Version range (e.g. >=5.1, <5.4)
+    version_range: $ => token(seq(
+      choice('>', '<', '>=', '<='),
+      /\d+(\.\d+)*/
+    )),
+
+    // @diagnostic annotation
+    diagnostic_annotation: $ => seq(
+      '@diagnostic',
+      field('action', choice('disable', 'enable', 'disable-next-line', 'disable-line')),
+      optional(seq(':', field('diagnostics', $.diagnostic_list)))
+    ),
+
+    // @operator annotation
+    operator_annotation: $ => seq(
+      '@operator',
+      '(',
+      field('op', $.operator),
+      ')',
+      optional(seq(
+        '(',
+        optional(field('params', $.param_list)),
+        ')'
+      )),
+      optional(seq(':', field('return_type', $.type_annotation_value)))
+    ),
+
+    // @source annotation
+    source_annotation: $ => seq(
+      '@source',
+      field('source', $.string)
+    ),
+
+    // @namespace annotation
+    namespace_annotation: $ => seq(
+      '@namespace',
+      field('name', $.identifier),
+      optional(field('description', $.description))
+    ),
+
+    // @using annotation
+    using_annotation: $ => seq(
+      '@using',
+      field('path', choice($.identifier, $.string)),
+      optional(field('description', $.description))
+    ),
+
+    // @export annotation
+    export_annotation: $ => '@export',
+
+    // @language annotation
+    language_annotation: $ => seq(
+      '@language',
+      field('language', $.identifier),
+      optional(field('description', $.description))
+    ),
+
+    // @attribute annotation (for defining custom attributes)
+    attribute_annotation: $ => seq(
+      '@attribute',
+      field('name', $.identifier),
+      optional(seq(
+        '(',
+        optional(field('params', $.attribute_params)),
+        ')'
+      )),
+      optional(field('description', $.description))
+    ),
+
+    // Attribute parameters
+    attribute_params: $ => seq(
+      $.attribute_param,
+      repeat(seq(',', $.attribute_param))
+    ),
+
+    // Attribute parameter
+    attribute_param: $ => seq(
+      field('name', $.identifier),
+      optional(seq(':', field('type', $.type)))
+    ),
+
+    // @[...] attribute use (for annotating other tags with attributes)
+    attribute_use: $ => seq(
+      '@[',
+      field('attributes', $.attribute_use_list),
+      ']'
+    ),
+
+    // Attribute use list
+    attribute_use_list: $ => seq(
+      $.attribute_use_item,
+      repeat(seq(',', $.attribute_use_item))
+    ),
+
+    // Single attribute use
+    attribute_use_item: $ => seq(
+      field('name', $.identifier),
+      optional(seq(
+        '(',
+        optional(field('args', $.attribute_args)),
+        ')'
+      ))
+    ),
+
+    // Attribute arguments
+    attribute_args: $ => seq(
+      $.attribute_arg,
+      repeat(seq(',', $.attribute_arg))
+    ),
+
+    // Attribute argument (can be literal or identifier)
+    attribute_arg: $ => choice(
+      $.string,
+      $.number,
+      $.boolean,
+      $.identifier
+    ),
+
+    // @readonly annotation
+    readonly_annotation: $ => '@readonly',
+
+    // @as annotation (for type casting expressions)
+    as_annotation: $ => seq(
+      '@as',
+      field('type', $.type_annotation_value),
+      optional(field('description', $.description))
+    ),
+
+    // Fallback for unknown/other annotations
+    other_annotation: $ => seq(
+      field('tag', $.tag_name),
+      optional(field('description', $.description))
+    ),
+
+    // Tag name for other annotations
+    tag_name: $ => token(/@[a-zA-Z_][a-zA-Z0-9_\-]*/),
+
+    // Type annotation value
+    type_annotation_value: $ => $.type_list,
+
+    // Return type annotation value
+    return_type_annotation: $ => $.type_list,
+
+    // Parameter type annotation value
+    param_type_annotation: $ => $.type_list,
+
+    // Type list
+    type_list: $ => prec.left(2, seq(
+      $.type,
+      repeat(prec.left(2, seq('|', $.type)))
+    )),
+
+    // Type
+    type: $ => prec.left(choice(
+      $.array_type,
+      $.conditional_type,
+      $.binary_type,
+      $.unary_type,
+      $.primary_type
+    )),
+
+    // Primary type (excluding arrays and operators)
+    primary_type: $ => choice(
+      $.basic_type,
+      $.table_type,
+      $.table_literal_type,
+      $.function_type,
+      $.generic_type,
+      $.literal_type,
+      $.parenthesized_type,
+      $.tuple_type,
+      $.template_type
+    ),
+
+    // Basic type
+    basic_type: $ => $.identifier,
+
+    // Array type
+    array_type: $ => prec(1, seq(
+      field('element', $.primary_type),
+      '[',
+      ']'
+    )),
+
+    // Table type
+    table_type: $ => seq(
+      'table',
+      optional(seq(
+        '<',
+        field('key', $.type),
+        ',',
+        field('value', $.type),
+        '>'
+      ))
+    ),
+
+    // Table literal type { field: type, ... }
+    table_literal_type: $ => seq(
+      '{',
+      optional(seq(
+        $.table_field,
+        repeat(seq(',', $.table_field)),
+        optional(',')
+      )),
+      '}'
+    ),
+
+    // Table field definition
+    table_field: $ => choice(
+      // Named field: name: type
+      seq(
+        field('name', $.identifier),
+        ':',
+        field('type', $.type_list)
+      ),
+      // Index field: [key]: type
+      seq(
+        '[',
+        field('key', $.type_list),
+        ']',
+        ':',
+        field('type', $.type_list)
+      )
+    ),
+
+    // Function type
+    function_type: $ => seq(
+      optional('async'),
+      'fun',
+      '(',
+      optional(field('params', $.param_list)),
+      ')',
+      optional(seq(':', field('return', choice(
+        $.type_list,
+        $.return_type_list  // Support comma-separated return types
+      ))))
+    ),
+
+    // Parameter list
+    param_list: $ => seq(
+      $.param_def,
+      repeat(seq(',', $.param_def))
+    ),
+
+    // Return type list (comma-separated for multiple returns)
+    return_type_list: $ => prec.left(seq(
+      $.type,
+      repeat(seq(',', $.type))
+    )),
+
+    // Parameter definition
+    param_def: $ => seq(
+      field('name', choice($.identifier, '...')),
+      optional(seq(':', field('type', $.type))),
+      optional('?')
+    ),
+
+    // Generic type
+    generic_type: $ => seq(
+      field('base', $.identifier),
+      '<',
+      field('params', $.generic_params_types),
+      '>'
+    ),
+
+    // Generic parameter type list (comma-separated)
+    generic_params_types: $ => seq(
+      $.type,
+      repeat(seq(',', $.type))
+    ),
+
+    // Literal type
+    literal_type: $ => choice(
+      $.string,
+      $.number,
+      $.boolean,
+      'nil'
+    ),
+
+    // Parenthesized type (supports union types)
+    parenthesized_type: $ => seq(
+      '(',
+      $.type_list,
+      ')'
+    ),
+
+    // Tuple type
+    tuple_type: $ => seq(
+      '[',
+      field('elements', $.tuple_elements),
+      ']'
+    ),
+
+    // Tuple element list
+    tuple_elements: $ => seq(
+      $.type_list,
+      repeat(seq(',', $.type_list)),
+      optional(',')  // Support trailing comma
+    ),
+
+    // Conditional type: condition and true_type or false_type
+    conditional_type: $ => prec.left(2, seq(
+      field('condition', $.type),
+      'and',
+      field('true_type', $.type),
+      'or',
+      field('false_type', $.type)
+    )),
+
+    // Binary type: union (|), intersection (&), extends, in
+    binary_type: $ => prec.left(choice(
+      seq(
+        field('left', $.primary_type),
+        field('op', choice('&', 'extends', 'in')),
+        field('right', $.primary_type)
+      )
+    )),
+
+    // Unary type: keyof, typeof
+    unary_type: $ => prec(3, seq(
+      field('op', choice('keyof', 'typeof')),
+      field('argument', $.primary_type)
+    )),
+
+    // Template type: `literal ${Type} literal`
+    template_type: $ => seq(
+      '`',
+      repeat(choice(
+        $.template_chars,
+        $.template_substitution
+      )),
+      '`'
+    ),
+
+    // Template characters
+    template_chars: $ => token(prec(-1, /[^`$]+|\$[^{]/)),
+
+    // Template substitution
+    template_substitution: $ => seq(
+      '${',
+      field('type', $.type),
+      '}'
+    ),
+
+    // Diagnostic list
+    diagnostic_list: $ => seq(
+      $.identifier,
+      repeat(seq(',', $.identifier))
+    ),
+
+    // Operator
+    operator: $ => choice(
+      'call',
+      'add', 'sub', 'mul', 'div', 'mod', 'pow',
+      'concat',
+      'len',
+      'eq', 'lt', 'le',
+      'unm',
+      'bnot', 'band', 'bor', 'bxor', 'shl', 'shr',
+      'index'  // For __index metamethod
+    ),
+
+    // Identifier (supports letters, numbers, underscores, dots and hyphens)
+    identifier: $ => /[a-zA-Z_][a-zA-Z0-9_\.\-]*/,
+
+    // String
+    string: $ => choice(
+      seq('"', /[^"]*/, '"'),
+      seq("'", /[^']*/, "'")
+    ),
+
+    // Number
+    number: $ => /\d+(\.\d+)?/,
+
+    // Boolean
+    boolean: $ => choice('true', 'false')
+
+    // Description is handled by external scanner
+  }
+});

--- a/langs/group-hazel/emmyluadoc/def/grammar/scanner.c
+++ b/langs/group-hazel/emmyluadoc/def/grammar/scanner.c
@@ -1,0 +1,136 @@
+#include "tree_sitter/parser.h"
+#include <wctype.h>
+#include <stdbool.h>
+
+enum TokenType {
+  TEXT_LINE,
+  DESCRIPTION,
+};
+
+void *tree_sitter_emmyluadoc_external_scanner_create() { return NULL; }
+
+void tree_sitter_emmyluadoc_external_scanner_destroy(void *payload) {}
+
+unsigned tree_sitter_emmyluadoc_external_scanner_serialize(void *payload, char *buffer) { return 0; }
+
+void tree_sitter_emmyluadoc_external_scanner_deserialize(void *payload, const char *buffer, unsigned length) {}
+
+static bool scan_text_line(TSLexer *lexer) {
+  // First, skip any leading newlines to get to the start of a line
+  while (lexer->lookahead == '\n' || lexer->lookahead == '\r') {
+    lexer->advance(lexer, true);
+  }
+
+  // After skipping newlines, we should be at column 0 (start of a line).
+  // If not at column 0, we're in the middle of a line -> not a text_line
+  if (lexer->get_column(lexer) != 0) {
+    return false;
+  }
+
+  // Now skip horizontal whitespace
+  while (lexer->lookahead == ' ' || lexer->lookahead == '\t') {
+    lexer->advance(lexer, true);
+  }
+
+  // If EOF -> not a text_line
+  if (lexer->lookahead == 0) return false;
+
+  // If another newline (empty line) -> not a text_line
+  if (lexer->lookahead == '\n' || lexer->lookahead == '\r') return false;
+
+  // Case 1: Starts with @ directly (e.g., "@class MyClass")
+  // According to new rules, @ without --- prefix should be treated as text_line
+  if (lexer->lookahead == '@') {
+    // Consume the entire line as text_line
+    while (lexer->lookahead != '\n' && lexer->lookahead != '\r' && lexer->lookahead != 0) {
+      lexer->advance(lexer, false);
+    }
+    lexer->result_symbol = TEXT_LINE;
+    lexer->mark_end(lexer);
+    return true;
+  }
+  
+  // Case 2: Starts with dash sequence (comment-like) e.g. ---something
+  if (lexer->lookahead == '-') {
+    int dash_count = 0;
+    // Count the dashes
+    while (lexer->lookahead == '-') {
+      dash_count++;
+      lexer->advance(lexer, true);
+    }
+
+    // Skip horizontal whitespace after dashes
+    while (lexer->lookahead == ' ' || lexer->lookahead == '\t') lexer->advance(lexer, true);
+
+    // If exactly 3 dashes followed by @ or @[ -> this is an annotation, not text_line
+    if (dash_count == 3 && lexer->lookahead == '@') return false;
+    
+    // If exactly 3 dashes followed by | -> this is a type continuation, not text_line
+    if (dash_count == 3 && lexer->lookahead == '|') return false;
+
+    // Otherwise consume to end of line and return TEXT_LINE
+    while (lexer->lookahead != '\n' && lexer->lookahead != '\r' && lexer->lookahead != 0) {
+      lexer->advance(lexer, true);
+    }
+    lexer->mark_end(lexer);
+    lexer->result_symbol = TEXT_LINE;
+    return true;
+  }
+  
+  // Case 3: Regular text line (doesn't start with - or @)
+  // Consume the entire line
+  while (lexer->lookahead != '\n' && lexer->lookahead != '\r' && lexer->lookahead != 0) {
+    lexer->advance(lexer, false);
+  }
+  
+  lexer->result_symbol = TEXT_LINE;
+  lexer->mark_end(lexer);
+  return true;
+}
+
+static bool scan_description(TSLexer *lexer) {
+  // Description starts with at least one space/tab
+  if (lexer->lookahead != ' ' && lexer->lookahead != '\t') {
+    return false;
+  }
+  
+  // Skip leading whitespace
+  while (lexer->lookahead == ' ' || lexer->lookahead == '\t') {
+    lexer->advance(lexer, false);
+  }
+  
+  // If we hit EOF or newline immediately, no description
+  if (lexer->lookahead == 0 || lexer->lookahead == '\n' || lexer->lookahead == '\r') {
+    return false;
+  }
+  
+  // Description cannot start with | or ,
+  if (lexer->lookahead == '|' || lexer->lookahead == ',') {
+    return false;
+  }
+  
+  // Consume until comma, newline, or EOF
+  // This allows description to work with comma-separated lists
+  while (lexer->lookahead != ',' && 
+         lexer->lookahead != '\n' && 
+         lexer->lookahead != '\r' && 
+         lexer->lookahead != 0) {
+    lexer->advance(lexer, false);
+  }
+  
+  lexer->mark_end(lexer);
+  lexer->result_symbol = DESCRIPTION;
+  return true;
+}
+
+bool tree_sitter_emmyluadoc_external_scanner_scan(void *payload, TSLexer *lexer, const bool *valid_symbols) {
+  if (valid_symbols[DESCRIPTION]) {
+    return scan_description(lexer);
+  }
+  
+  if (valid_symbols[TEXT_LINE]) {
+    return scan_text_line(lexer);
+  }
+  
+  return false;
+}

--- a/langs/group-hazel/emmyluadoc/def/queries/highlights.scm
+++ b/langs/group-hazel/emmyluadoc/def/queries/highlights.scm
@@ -1,0 +1,240 @@
+; Highlights query for EmmyLuaDoc
+
+; Comment Prefix
+(comment_prefix) @comment
+
+; Annotation Keywords
+"@class" @keyword
+"@interface" @keyword
+"@field" @keyword
+"@type" @keyword
+"@param" @keyword
+"@return" @keyword
+"@generic" @keyword
+"@overload" @keyword
+"@see" @keyword
+"@alias" @keyword
+"@enum" @keyword
+"@module" @keyword
+"@cast" @keyword
+"@version" @keyword
+"@diagnostic" @keyword
+"@operator" @keyword
+"@namespace" @keyword
+"@using" @keyword
+"@language" @keyword
+"@attribute" @keyword
+"@as" @keyword
+
+; Other/unknown annotations
+(tag_name) @keyword
+
+; Special annotation nodes
+(deprecated_annotation) @keyword
+(private_annotation) @keyword
+(protected_annotation) @keyword
+(public_annotation) @keyword
+(package_annotation) @keyword
+(async_annotation) @keyword
+(nodiscard_annotation) @keyword
+(meta_annotation) @keyword
+(readonly_annotation) @keyword
+(export_annotation) @keyword
+
+; Visibility modifiers
+[
+  "public"
+  "private"
+  "protected"
+  "package"
+] @keyword.modifier
+
+; Type keywords
+[
+  "fun"
+  "async"
+  "table"
+  "keyof"
+  "typeof"
+  "extends"
+  "in"
+  "and"
+  "or"
+] @keyword.type
+
+; Identifiers
+(identifier) @variable
+
+; Types
+(basic_type
+  (identifier) @type)
+
+; Built-in types
+((identifier) @type.builtin
+  (#match? @type.builtin "^(string|number|integer|boolean|table|function|thread|userdata|nil|any|unknown|self)$"))
+
+; Class definitions
+(class_annotation
+  name: (identifier) @type.definition)
+
+; Class parent types
+(class_annotation
+  parent: (type_list
+    (type
+      (primary_type
+        (basic_type
+          (identifier) @type)))))
+
+; Class modifiers
+(class_annotation
+  [
+    "exact"
+    "partial"
+    "constructor"
+  ] @keyword.modifier)
+
+; Fields and Parameters
+(field_annotation
+  name: (field_name) @variable.member)
+
+(param_annotation
+  name: (param_name) @variable.parameter)
+
+(param_def
+  name: (identifier) @variable.parameter)
+
+; Generics
+(generic_annotation
+  name: (identifier) @type.parameter)
+
+(generic_type
+  base: (identifier) @type)
+
+(generic_params
+  params: (identifier) @type.parameter)
+
+; Aliases and Enums
+(alias_annotation
+  name: (identifier) @type.definition)
+
+(enum_annotation
+  name: (identifier) @type.definition)
+
+; Enum modifiers
+(enum_annotation
+  "key" @keyword.modifier)
+
+; Operators
+[
+  "call"
+  "add" "sub" "mul" "div" "mod" "pow"
+  "concat"
+  "len"
+  "eq" "lt" "le"
+  "unm"
+  "bnot" "band" "bor" "bxor" "shl" "shr"
+  "index"
+] @operator
+
+; Literals
+(string) @string
+(number) @number
+(boolean) @boolean
+"nil" @constant.builtin
+
+; Template types
+(template_chars) @string
+
+; Text line (documentation text)
+(text_line) @comment
+
+; Description
+(description) @comment
+
+; Other annotation description (highlight differently for visibility)
+(other_annotation
+  description: (description) @string.documentation)
+
+; Continuation description
+(continuation_description) @comment
+
+; Punctuation
+[
+  ":"
+  "|"
+  ","
+  "?"
+] @punctuation.delimiter
+
+[
+  "("
+  ")"
+  "["
+  "]"
+  "<"
+  ">"
+  "{"
+  "}"
+] @punctuation.bracket
+
+; Function type
+(function_type
+  "fun" @keyword.function)
+
+; Table type
+(table_type
+  "table" @type.builtin)
+
+; Table fields
+(table_field
+  name: (identifier) @property)
+
+; Diagnostic actions
+(diagnostic_annotation
+  action: [
+    "disable"
+    "enable"
+    "disable-next-line"
+    "disable-line"
+  ] @keyword.directive)
+
+(diagnostic_list
+  (identifier) @constant)
+
+; Attributes
+(attribute_use_item
+  name: (identifier) @function.macro)
+
+(attribute_annotation
+  name: (identifier) @function.macro)
+
+; Module names
+(module_annotation
+  name: (string) @module)
+
+; Version
+(version_annotation
+  version: [
+    (identifier) @constant
+    (string) @string
+    (version_range) @constant
+  ])
+
+; See references
+(see_annotation
+  reference: (identifier) @variable)
+
+; Namespace
+(namespace_annotation
+  name: (identifier) @namespace)
+
+; Using
+(using_annotation
+  path: [
+    (identifier) @namespace
+    (string) @string
+  ])
+
+; Language
+(language_annotation
+  language: (identifier) @constant)

--- a/langs/group-hazel/emmyluadoc/def/queries/locals.scm
+++ b/langs/group-hazel/emmyluadoc/def/queries/locals.scm
@@ -1,0 +1,26 @@
+; Locals query for EmmyLuaDoc
+(class_annotation) @scope
+
+(class_annotation
+  name: (identifier) @definition.type)
+
+(field_annotation
+  name: (field_name) @definition.field)
+
+(param_annotation
+  name: (param_name) @definition.parameter)
+
+(generic_annotation
+  name: (identifier) @definition.type)
+
+(alias_annotation
+  name: (identifier) @definition.type)
+
+(enum_annotation
+  name: (identifier) @definition.type)
+
+(basic_type
+  (identifier) @reference)
+
+(param_def
+  name: (identifier) @reference)

--- a/langs/group-hazel/emmyluadoc/def/samples/luadoc.lua
+++ b/langs/group-hazel/emmyluadoc/def/samples/luadoc.lua
@@ -1,0 +1,21 @@
+---@class Person
+---@field name string
+---@field age number
+local Person = {}
+
+---Creates a new person
+---@param name string The person's name
+---@param age number The person's age
+---@return Person The created person instance
+function Person.new(name, age)
+    local self = setmetatable({}, { __index = Person })
+    self.name = name
+    self.age = age
+    return self
+end
+
+---@param person Person
+---@return string
+function Person.greet(person)
+    return "Hello, " .. person.name .. "!"
+end

--- a/langs/group-hazel/lua/def/arborium.yaml
+++ b/langs/group-hazel/lua/def/arborium.yaml
@@ -10,6 +10,9 @@ grammars:
     has_scanner: true
     icon: devicon-plain:lua
 
+    injections:
+      - emmyluadoc
+
     inventor: Roberto Ierusalimschy, Waldemar Celes, Luiz Henrique de Figueiredo
     year: 1993
     description: "Lightweight embeddable scripting language from PUC-Rio; <a href=\"https://www.lua.org/manual/5.4/\">official reference manual</a>."

--- a/langs/group-hazel/lua/def/queries/injections.scm
+++ b/langs/group-hazel/lua/def/queries/injections.scm
@@ -1,3 +1,8 @@
+; Parse EmmyLua/LuaCATS documentation comments with the EmmyLuaDoc grammar.
+(((comment) @_emmyluadoc_comment
+  (#match? @_emmyluadoc_comment "^---")) @injection.content
+  (#set! injection.language "emmyluadoc"))
+
 ((function_call
   name: [
     (identifier) @_cdef_identifier


### PR DESCRIPTION
Adds support for LuaCATS / EmmyLuaDoc style type-annotations inside Lua comments.
Tree-sitter: [EmmyLuaLs/tree-sitter-emmyluadoc](https://github.com/EmmyLuaLs/tree-sitter-emmyluadoc)

LuaCATS is a fork of EmmyluaDoc and while the two have since diverged somewhat `tree-sitter-emmyluadoc` can happily parse either.  Adapted from the [Zed Lua Extension](https://github.com/zed-extensions/lua).

LLM Notice: Used GPT-5.6-Sol High in Codex

## Screenshot

<img width="1031" height="481" alt="luadoc-arborium" src="https://github.com/user-attachments/assets/7e446846-60ec-48a9-8028-d8513e28d309" />

